### PR TITLE
shapes: add initial SHACL shapes for R2RML and RML

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pipenv
+        pipenv install
+    - name: Run tests
+      run: |
+        pipenv run python3 tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.iml
 .idea/
+*__pycache__

--- a/Shapes/LICENSE
+++ b/Shapes/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2021 Dylan Van Assche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Shapes/Pipfile
+++ b/Shapes/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+parameterized = "*"
+rdflib = "*"
+pyshacl = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/Shapes/Pipfile.lock
+++ b/Shapes/Pipfile.lock
@@ -1,0 +1,73 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c09550ebf65e67d20f70972421db04379ae8c9622cbd3aec79fd69d33c1b78b3"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
+        },
+        "owlrl": {
+            "hashes": [
+                "sha256:0514239bfbf72fa67f3e5813a40bcc5bd88fd16093d9f76b45a0d4c84ee1c5e2",
+                "sha256:b1891d75b2c2fb0db9e1504a9b12dab738ed89236414c51393d1030597004342"
+            ],
+            "version": "==5.2.3"
+        },
+        "parameterized": {
+            "hashes": [
+                "sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c",
+                "sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9"
+            ],
+            "index": "pypi",
+            "version": "==0.8.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "pyshacl": {
+            "hashes": [
+                "sha256:4c1e3792432985acd247e0cdae508540772df237ccd0970a8b7dbd1a1552ca81",
+                "sha256:df07c22a60ecc714a1e78455d48c8b646847c2f32d01c6f5ff31fd101bd9e089"
+            ],
+            "index": "pypi",
+            "version": "==0.17.0.post2"
+        },
+        "rdflib": {
+            "hashes": [
+                "sha256:a775069ab1c3d38b7e04666603666fb8a31937a4671a5afc91ca136109f8047a",
+                "sha256:f071caff0b68634e4a7bd1d66ea3416ac98f1cc3b915938147ea899c32608728"
+            ],
+            "index": "pypi",
+            "version": "==6.0.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "version": "==1.16.0"
+        }
+    },
+    "develop": {}
+}

--- a/Shapes/README.md
+++ b/Shapes/README.md
@@ -1,0 +1,7 @@
+# SHACL shapes for RML mapping rules
+
+SHACL shapes to validate RML mapping rules.
+
+## License
+
+This code is copyrighted by [IDLab – Ghent University – imec](http://idlab.ugent.be/) and released under the [MIT license](http://opensource.org/licenses/MIT).

--- a/Shapes/mapping_validator.py
+++ b/Shapes/mapping_validator.py
@@ -1,0 +1,40 @@
+from logging import debug, info, critical
+from pyshacl import validate
+from rdflib import Graph
+from shutil import get_terminal_size
+
+
+class MappingValidator:
+    def __init__(self, shape: str) -> None:
+        g = Graph()
+        g.parse(shape, format='turtle')
+        self._shape = g
+
+    def validate(self, rules: Graph, print_report: bool = True) -> None:
+        valid: bool
+        report_graph: Graph
+        report_text: str
+        valid, report_graph, report_text = validate(rules,
+                                                    shacl_graph=self._shape)
+        debug(f'RML rules valid: {valid}')
+        debug(f'SHACL validation report: {report_text}')
+
+        # If mapping rules are invalid, print SHACL report and raise exception
+        if not valid and print_report:
+            self._print_report(report_text)
+            msg = 'RML mapping rules are invalid, a detailed explanation' \
+            ' is available in the report'
+            critical(msg)
+            raise ValueError(msg)
+
+    def _print_report(self, report_text: str) -> None:
+        tty_columns: int
+        tty_columns, _ = get_terminal_size()
+        info('-' * tty_columns)
+        title: str = 'RML rules validation report'
+        white_space: int = int((tty_columns - len(title)) / 2)
+        title = ' ' * white_space + title + ' ' * white_space
+        info(title)
+        info('-' * tty_columns)
+        info(report_text)
+        info('-' * tty_columns)

--- a/Shapes/rml_v1_shape.ttl
+++ b/Shapes/rml_v1_shape.ttl
@@ -1,0 +1,1703 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://schema.org/CSVWTableSchema> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An object property that provides a single schema description, used as the 
+    default for all the tables in the group.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    TableSchema description for a CSVW Table. 1 csvw:columns is required.
+    """ ;
+    sh:name "csvw:TableSchema" ;
+    sh:property [ sh:description """
+        csvw:column with string values interpreted as identifier with array 
+        values interpreted as rdf:List.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        At least one CSVW Column is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "csvw:columns" ;
+            sh:node <http://datashapes.org/dash#ListShape> ;
+            sh:path <http://www.w3.org/ns/csvw#columns> ;
+            sh:property [ sh:closed true ;
+                    sh:minCount 1 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+                    sh:property [ sh:datatype xsd:string ;
+                            sh:description """
+                An atomic property that gives a single canonical name for the 
+                column. The value of this property becomes the name annotation 
+                for the described column.
+                May only be provided once.
+                """ ;
+                            sh:maxCount 1 ;
+                            sh:message """
+                csvw:name must be a string and is required.
+                """ ;
+                            sh:minCount 1 ;
+                            sh:minLength 1 ;
+                            sh:name "csvw:name" ;
+                            sh:nodeKind sh:Literal ;
+                            sh:path <http://www.w3.org/ns/csvw#name> ],
+                        [ sh:datatype xsd:string ;
+                            sh:description """
+                An atomic property giving the string or strings used for null 
+                values within the data. If the string value of the cell is 
+                equal to any one of these values, the cell value is `null`.
+                """ ;
+                            sh:maxCount 1 ;
+                            sh:message """
+                csvw:null must be a string and is optional.
+                May only be provided once.
+                """ ;
+                            sh:minCount 0 ;
+                            sh:name "csvw:null" ;
+                            sh:nodeKind sh:Literal ;
+                            sh:path <http://www.w3.org/ns/csvw#null> ] ] ] ;
+    sh:targetClass <http://www.w3.org/ns/csvw#TableSchema> .
+
+<http://schema.org/D2RQDatabaseShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An RML Logical Source: D2RQ Database describes how a relational database 
+    needs to be accessed.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    An RML Logical Source description for a D2RQ Database requires exactly
+    one d2rq:jdbcDSN, one d2rq:jdbcDriver. d2rq:username and d2rq:password are
+    optional.
+    """ ;
+    sh:name "RML Logical Source description: D2RQ Database" ;
+    sh:or ( [ sh:and ( [ sh:minCount 1 ;
+                            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#username> ] [ sh:minCount 1 ;
+                            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#password> ] ) ] [ sh:and ( [ sh:minCount 0 ;
+                            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#username> ] [ sh:maxCount 0 ;
+                            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#password> ] ) ] ) ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description """
+        The JDBC database URL.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The JDBC database URL must be a string of the form: 
+        'jdbc:{subprotocol}:{subname}://{hostname}:{port}/{dbname}'
+        and may only be provided once.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "d2rq:jdbcDSN" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#jdbcDSN> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The JDBC driver class name for the database. Used together with 
+        d2rq:jdbcDSN.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The JDBC driver for the database must be specified.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "d2rq:jdbcDriver" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#jdbcDriver> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A username if required by the database.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The username for the database must be a string. 
+        """ ;
+            sh:minCount 0 ;
+            sh:name "d2rq:username" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#username> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A password if required by the database.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The password for the database must be a string. 
+        """ ;
+            sh:minCount 0 ;
+            sh:name "d2rq:password" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#password> ] ;
+    sh:targetClass <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#Database> .
+
+<http://schema.org/RRLogicalTable> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents a logical table.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:LogicalTable must provide either one rr:tableName or one rr:sqlQuery.
+    rr:sqlVersion is optional. 
+    """ ;
+    sh:name "rr:LogicalTable" ;
+    sh:property [ sh:description """
+        Exactly one rr:tableName or one rr:sqlQuery is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rr:tableName or one rr:sqlQuery is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:tableName/rr:sqlQuery" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#tableName> <http://www.w3.org/ns/r2rml#sqlQuery> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        Schema-qualified name of a table or view.
+        """ ;
+            sh:message """
+        rr:tableName must be a string and may only be provided once.
+        """ ;
+            sh:name "rr:tableName" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#tableName> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A valid SQL query.
+        """ ;
+            sh:message """
+        rr:sqlQuery must be a string and may only be provided once.
+        """ ;
+            sh:name "rr:sqlQuery" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#sqlQuery> ],
+        [ sh:description """
+        An identifier for a SQL version.
+        """ ;
+            sh:in ( <http://www.w3.org/ns/r2rml#SQL2008> ) ;
+            sh:message """
+        rr:sqlVersion may only be provided once and must its value must be 
+        rr:SQL2008.
+        """ ;
+            sh:name "rr:sqlVersion" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#sqlVersion> ] .
+
+<http://schema.org/RRTriplesMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents a triples map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:TriplesMap requires exactly one rr:subject or one rr:subjectMap and zero
+    or more rr:predicateObjectMaps.
+    """,
+        "rr:TriplesMap" ;
+    sh:property [ sh:description """
+        An IRI reference for use as subject for all the RDF triples generated 
+        from a logical table row or iterator.
+        """ ;
+            sh:message """
+        rr:subject must be an IRI or blank node.
+        """ ;
+            sh:name "rr:subject" ;
+            sh:node <http://schema.org/RRsubjectShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#subject> ],
+        [ sh:description """
+        A PredicateObjectMap element to generate (predicate, object) pair from 
+        a logical table row.
+        """ ;
+            sh:message """
+        rr:PredicateObjectMap must be an IRI or blank node.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:predicateObjectMap" ;
+            sh:node <http://schema.org/RRPredicateObjectMapShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#predicateObjectMap> ],
+        [ sh:description """
+        Either one rr:logicalTable or one rml:logicalSource is required, not 
+        both.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Either one rr:logicalTable or one rml:logicalSource is required, not 
+        both.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:logicalTable/rml:logicalSource" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#logicalTable> <http://semweb.mmlab.be/ns/rml#logicalSource> ) ] ],
+        [ sh:description """
+        Definition of logical table to be mapped.
+        """ ;
+            sh:message """
+        Exactly one rr:logicalTable is required to access a relational 
+        database.
+        """ ;
+            sh:name "rr:logicalTable" ;
+            sh:node <http://schema.org/RRLogicalTableShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#logicalTable> ],
+        [ sh:description """
+        A logical source is any source that is mapped to RDF triples. A logical 
+        source is a Base Source, rml:BaseSource.
+        """ ;
+            sh:message """
+        Exactly one rml:logicalSource is required to access the data source.
+        """ ;
+            sh:name "rml:logicalSource" ;
+            sh:node <http://schema.org/RMLLogicalSourceShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://semweb.mmlab.be/ns/rml#logicalSource> ],
+        [ sh:description """
+        Either one rr:subject or one rr:SubjectMap is required, not both.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Either one rr:subject or one rr:SubjectMap is required, not both.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:subjectMap/rr:subject" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#subjectMap> <http://www.w3.org/ns/r2rml#subject> ) ] ],
+        [ sh:description """
+        A SubjectMap element to generate a subject from a logical table row or
+        iterator.
+        """ ;
+            sh:message """
+        rr:SubjectMap must be an IRI or blank node.
+        """ ;
+            sh:name "rr:subjectMap" ;
+            sh:node <http://schema.org/RRSubjectMapShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#subjectMap> ] ;
+    sh:targetClass <http://www.w3.org/ns/r2rml#TriplesMap> .
+
+<http://schema.org/CSVFileShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:property [ sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+            sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+
+        Locating CSV files is possible using a DCAT dataset description, 
+        a CSVW Table description or a file path to a local file.
+        """ ;
+            sh:name "rml:source" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#source> ;
+            sh:xone ( [ sh:datatype xsd:string ;
+                        sh:nodeKind sh:Literal ] [ sh:class <http://www.w3.org/ns/csvw#Table> ;
+                        sh:node <http://schema.org/CSVWTableShape> ;
+                        sh:nodeKind sh:BlankNodeOrIRI ] [ sh:class <http://www.w3.org/ns/dcat#Dataset> ;
+                        sh:node <http://schema.org/DCATDatasetShape> ;
+                        sh:nodeKind sh:BlankNodeOrIRI ] ) ],
+        [ sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+            sh:in ( <http://semweb.mmlab.be/ns/ql#CSV> <http://semweb.mmlab.be/ns/ql#TSV> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        Reference formulation for CSV files must be ql:CSV.
+        TSV files must use ql:TSV. Providing rml:referenceFormulation for 
+        tabular data is optional.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:referenceFormulation" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ] .
+
+<http://schema.org/CSVWDialectShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Dialect description for a CSVW Table. One csvw:delimiter, one csvw:encoding,
+    one csvw:doubleQuote, one csvw:quoteChar, one csvw:escapeChar, one 
+    csvw:lineTerminators, one csvw:trim, one csvw:skipInitialSpace, one 
+    csvw:header, one csvw:headerRowCount, one csvw:skipColumns, one 
+    csvw:skipRows and one csvw:commentPrefix are optional.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message "CSVW Dialect violation" ;
+    sh:name "csvw:Dialect" ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description """
+        An atomic property that sets the line terminators flag to either an 
+        array containing the single provided string value, or the provided 
+        array.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The line terminators must be a string with a length of at least 1.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minLength 1 ;
+            sh:name "csvw:lineTerminators" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#lineTerminators> ],
+        [ sh:description """
+        An atomic property that, if the boolean `true`, sets the trim flag to 
+        `true` and if the boolean `false` to `false`. If the value provided is 
+        a string, sets the trim flag to the provided value, which must be one 
+        of "true", "false", "start" or "end".
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Trim mode must be either a boolean or a string with value "true", 
+        "false", "start" or "end". May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:trim" ;
+            sh:nodeKind sh:Literal ;
+            sh:or ( [ sh:datatype xsd:string ;
+                        sh:in ( "true" "false" "start" "end" ) ] [ sh:datatype xsd:boolean ;
+                        sh:in ( true false ) ] ) ;
+            sh:path <http://www.w3.org/ns/csvw#trim> ],
+        [ sh:datatype xsd:boolean ;
+            sh:description """
+        A boolean atomic property that, if `true`, sets the trim flag to 
+        "start". If `false`, to `false`.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Skip initial space flag must be a boolean. May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:skipInitialSpace" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#skipInitialSpace> ],
+        [ sh:datatype xsd:boolean ;
+            sh:description """
+        A boolean atomic property that, if `true`, sets the header row count 
+        flag to `1`, and if `false` to `0`, unless headerRowCount is provided, 
+        in which case the value provided for the header property is ignored.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Header flag must be a boolean. May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:header" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#header> ],
+        [ sh:datatype xsd:integer ;
+            sh:description """
+        An numeric atomic property that sets the header row count flag to the 
+        single provided value, which must be a non-negative integer.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The header row count must be a non-negative integer. May only be 
+        provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minInclusive 0 ;
+            sh:name "csvw:headerRowCount" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#headerRowCount> ],
+        [ sh:datatype xsd:integer ;
+            sh:description """
+        An numeric atomic property that sets the `skip columns` flag to the 
+        single provided numeric value, which MUST be a non-negative integer.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Skip columns must be a non-negative integer. May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minInclusive 0 ;
+            sh:name "csvw:skipColumns" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#skipColumns> ],
+        [ sh:datatype xsd:integer ;
+            sh:description """
+        An numeric atomic property that sets the `skip rows` flag to the single 
+        provided numeric value, which MUST be a non-negative integer.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Skip rows must be a non-negative integer. May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minInclusive 0 ;
+            sh:name "csvw:skipRows" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#skipRows> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        An atomic property that sets the comment prefix flag to the single 
+        provided value, which MUST be a string.
+        """ ;
+            sh:maxCount 1 ;
+            sh:maxLength 1 ;
+            sh:message """
+        Comment prefix must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minLength 1 ;
+            sh:name "csvw:commentPrefix" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#commentPrefix> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        An atomic property that sets the delimiter flag to the single provided 
+        value, which MUST be a string.
+        """ ;
+            sh:maxCount 1 ;
+            sh:maxLength 1 ;
+            sh:message """
+        The delimiter must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minLength 1 ;
+            sh:name "csvw:delimiter" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#delimiter> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        An atomic property that sets the encoding flag to the single provided 
+        string value, which MUST be a defined in [encoding]. The default is 
+        "utf-8".
+
+        [encoding] https://encoding.spec.whatwg.org/
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The file encoding must match with the file encodings listed in 
+        https://encoding.spec.whatwg.org/.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:encoding" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#encoding> ;
+            sh:pattern "(unicode-1-1-utf-8)|(unicode11utf8)|(unicode20utf8)|(utf-8)|(utf8)|(x-unicode20utf8)|(866)|(cp866)|(csibm866)|(ibm866)|(csisolatin2)|(iso-8859-2)|(iso-ir-101)|(iso8859-2)|(iso88592)|(iso_8859-2)|(iso_8859-2:1987)|(l2)|(latin2)|(csisolatin3)|(iso-8859-3)|(iso-ir-109)|(iso8859-3)|(iso88593)|(iso_8859-3)|(iso_8859-3:1988)|(l3)|(latin3)|(csisolatin4)|(iso-8859-4)|(iso-ir-110)|(iso8859-4)|(iso88594)|(iso_8859-4)|(iso_8859-4:1988)|(l4)|(latin4)|(csisolatincyrillic)|(cyrillic)|(iso-8859-5)|(iso-ir-144)|(iso8859-5)|(iso88595)|(iso_8859-5)|(iso_8859-5:1988)|(arabic)|(asmo-708)|(csiso88596e)|(csiso88596i)|(csisolatinarabic)|(ecma-114)|(iso-8859-6)|(iso-8859-6-e)|(iso-8859-6-i)|(iso-ir-127)|(iso8859-6)|(iso88596)|(iso_8859-6)|(iso_8859-6:1987)|(csisolatingreek)|(ecma-118)|(elot_928)|(greek)|(greek8)|(iso-8859-7)|(iso-ir-126)|(iso8859-7)|(iso88597)|(iso_8859-7)|(iso_8859-7:1987)|(sun_eu_greek)|(csiso88598e)|(csisolatinhebrew)|(hebrew)|(iso-8859-8)|(iso-8859-8-e)|(iso-ir-138)|(iso8859-8)|(iso88598)|(iso_8859-8)|(iso_8859-8:1988)|(visual)|(csiso88598i)|(iso-8859-8-i)|(logical)|(csisolatin6)|(iso-8859-10)|(iso-ir-157)|(iso8859-10)|(iso885910)|(l6)|(latin6)|(iso-8859-13)|(iso8859-13)|(iso885913)|(iso-8859-14)|(iso8859-14)|(iso885914)|(csisolatin9)|(iso-8859-15)|(iso8859-15)|(iso885915)|(iso_8859-15)|(l9)|(iso-8859-16)|(cskoi8r)|(koi)|(koi8)|(koi8-r)|(koi8_r)|(koi8-ru)|(koi8-u)|(csmacintosh)|(mac)|(macintosh)|(x-mac-roman)|(dos-874)|(iso-8859-11)|(iso8859-11)|(iso885911)|(tis-620)|(windows-874)|(cp1250)|(windows-1250)|(x-cp1250)|(cp1251)|(windows-1251)|(x-cp1251)|(ansi_x3.4-1968)|(ascii)|(cp1252)|(cp819)|(csisolatin1)|(ibm819)|(iso-8859-1)|(iso-ir-100)|(iso8859-1)|(iso88591)|(iso_8859-1)|(iso_8859-1:1987)|(l1)|(latin1)|(us-ascii)|(windows-1252)|(x-cp1252)|(cp1253)|(windows-1253)|(x-cp1253)|(cp1254)|(csisolatin5)|(iso-8859-9)|(iso-ir-148)|(iso8859-9)|(iso88599)|(iso_8859-9)|(iso_8859-9:1989)|(l5)|(latin5)|(windows-1254)|(x-cp1254)|(cp1255)|(windows-1255)|(x-cp1255)|(cp1256)|(windows-1256)|(x-cp1256)|(cp1257)|(windows-1257)|(x-cp1257)|(cp1258)|(windows-1258)|(x-cp1258)|(x-mac-cyrillic)|(x-mac-ukrainian)|(chinese)|(csgb2312)|(csiso58gb231280)|(gb2312)|(gb_2312)|(gb_2312-80)|(gbk)|(iso-ir-58)|(x-gbk)|(gb18030)|(big5)|(big5-hkscs)|(cn-big5)|(csbig5)|(x-x-big5)|(cseucpkdfmtjapanese)|(euc-jp)|(x-euc-jp)|(csiso2022jp)|(iso-2022-jp)|(csshiftjis)|(ms932)|(ms_kanji)|(shift-jis)|(shift_jis)|(sjis)|(windows-31j)|(x-sjis)|(cseuckr)|(csksc56011987)|(euc-kr)|(iso-ir-149)|(korean)|(ks_c_5601-1987)|(ks_c_5601-1989)|(ksc5601)|(ksc_5601)|(windows-949)|(csiso2022kr)|(hz-gb-2312)|(iso-2022-cn)|(iso-2022-cn-ext)|(iso-2022-kr)|(replacement)|(unicodefffe)|(utf-16be)|(csunicode)|(iso-10646-ucs-2)|(ucs-2)|(unicode)|(unicodefeff)|(utf-16)|(utf-16le)|(x-user-defined)" ],
+        [ sh:datatype xsd:boolean ;
+            sh:description """
+        A boolean atomic property that, if `true`, sets the escape character 
+        flag to `"`.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The doubleQuote flag must be a boolean.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:doubleQuote" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#doubleQuote> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        An atomic property that sets the quote character flag to the single 
+        provided value, which must be a string or `null`.
+        """ ;
+            sh:maxCount 1 ;
+            sh:maxLength 1 ;
+            sh:message """
+        The quote character must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minLength 1 ;
+            sh:name "csvw:quoteChar" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#quoteChar> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The escape character to use when escaping special characters in the CSV
+        file.
+        Unofficially! Not supported by the CSVW specification!
+        """ ;
+            sh:maxCount 1 ;
+            sh:maxLength 1 ;
+            sh:message """
+        The escape character must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+            sh:minCount 0 ;
+            sh:minLength 1 ;
+            sh:name "csvw:escapeChar" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#escapeChar> ] ;
+    sh:targetClass <http://www.w3.org/ns/csvw#Dialect> .
+
+<http://schema.org/CSVWTableShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An RML Logical Source: CSVW Table describes how a CSV needs to be accessed
+    and processed.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    An RML Logical Source description for a CSVW Table requires exactly one
+    csvw:url and optionally one csvw:dialect or one csvw:tableSchema.
+    """ ;
+    sh:name "RML Logical Source: CSVW Table" ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description """
+        This link property gives the single URL of the CSV file that the table 
+        is held in, relative to the location of the metadata document. 
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        The csvw:url must be a string URL pointing to the location of the CSV 
+        file.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "csvw:url" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/csvw#url> ],
+        [ sh:description """
+        An object property that provides a single dialect description. If 
+        provided, dialect provides hints to processors about how to parse the 
+        referenced files to create tabular data models for the tables in the 
+        group.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        A single csvw:Dialect description is expected. The dialect description 
+        is optional and falls back to the default dialect specified in the CSVW
+        specification.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:dialect" ;
+            sh:node <http://schema.org/CSVWDialectShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/csvw#dialect> ],
+        [ sh:description """
+        An object property that provides a single schema, used as the default 
+        for all the tables in the group.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        A single csvw:TableSchema description is expected. The table schema 
+        description is optional and fallsback to extracting the CSV header from
+        the CSV file itself. 
+        """ ;
+            sh:minCount 0 ;
+            sh:name "csvw:tableSchema" ;
+            sh:node <http://schema.org/CSVWTableSchemaShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/csvw#tableSchema> ] ;
+    sh:targetClass <http://www.w3.org/ns/csvw#Table> .
+
+<http://schema.org/JSONOrXMLFileShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:property [ sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+            sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        """ ;
+            sh:name "rml:source" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#source> ;
+            sh:xone ( [ sh:datatype xsd:string ;
+                        sh:nodeKind sh:Literal ] [ sh:class <http://www.w3.org/ns/dcat#Dataset> ;
+                        sh:node <http://schema.org/DCATDatasetShape> ;
+                        sh:nodeKind sh:BlankNodeOrIRI ] ) ],
+        [ sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+            sh:in ( <http://semweb.mmlab.be/ns/ql#JSONPath> <http://semweb.mmlab.be/ns/ql#XPath> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        Reference formulation for XML or JSON files must be either ql:JSONPath
+        or ql:XPath.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rml:referenceFormulation" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The logical iterator (rml:iterator) defines the iteration loop used to 
+        map the data of the input source.  
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:iterator is required to iterate over the data source. May only be
+        provided once as a string.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rml:iterator" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#iterator> ] .
+
+<http://schema.org/RDBShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:property [ sh:class <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#Database> ;
+            sh:name "rml:source" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://semweb.mmlab.be/ns/rml#source> ;
+            sh:property [ sh:datatype xsd:string ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:name "D2RQ jdbc DSN" ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#jdbcDSN> ],
+                [ sh:datatype xsd:string ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:name "D2RQ jdbc Driver" ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#jdbcDriver> ],
+                [ sh:datatype xsd:string ;
+                    sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:name "D2RQ username" ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#username> ],
+                [ sh:datatype xsd:string ;
+                    sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:name "D2RQ password" ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#password> ] ],
+        [ sh:description """
+
+        """ ;
+            sh:in ( <http://www.w3.org/ns/r2rml#SQL2008> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:sqlVersion must be rr:SQL2008. Providing rr:sqlVersion is optional.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:sqlVersion" ;
+            sh:path <http://www.w3.org/ns/r2rml#sqlVersion> ],
+        [ sh:description """
+        Exactly one rml:query or one rr:sqlQuery or one rr:tableName must be 
+        provided to access the relational database.
+        """ ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:name "rml:query/rr:sqlQuery/rr:tableName" ;
+            sh:path [ sh:alternativePath ( <http://semweb.mmlab.be/ns/rml#query> <http://www.w3.org/ns/r2rml#sqlQuery> <http://www.w3.org/ns/r2rml#tableName> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        An R2RML view is a logical table whose contents are the result of 
+        executing a SQL query against the input database. It is represented by 
+        a resource that has exactly one rr:sqlQuery property, whose value is a 
+        literal with a lexical form that is a valid SQL query.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:sqlQuery is required for querying a relational database. 
+        Must be provided once as a string.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:sqlQuery" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#sqlQuery> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The query to execute on the data source.
+        rml:query is unofficially supported by RML, but not in the 
+        specification.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:query is required for relational database. 
+        Must be provided once as a string.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:query" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#query> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The value of rr:tableName specifies the table or view name of 
+        the base table or view. Its value MUST be a valid 
+        schema-qualified name that names an existing base table or 
+        view in the input database.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:tableName must be a string Literal and may only be provided 
+        once.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:tableName" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#tableName> ],
+        [ sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+            sh:in ( <http://semweb.mmlab.be/ns/ql#CSV> <http://semweb.mmlab.be/ns/ql#TSV> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        Reference formulation for CSV files must be ql:CSV.
+        TSV files must use ql:TSV. Providing rml:referenceFormulation for 
+        tabular data is optional.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:referenceFormulation" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ] .
+
+<http://schema.org/RDFFileShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:property [ sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+            sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        
+        Locating RDF files is possible using a DCAT dataset description or a 
+        file path to a local file.
+        """ ;
+            sh:name "rml:source" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#source> ;
+            sh:xone ( [ sh:datatype xsd:string ;
+                        sh:nodeKind sh:Literal ] [ sh:class <http://www.w3.org/ns/dcat#Dataset> ;
+                        sh:node <http://schema.org/DCATDatasetShape> ;
+                        sh:nodeKind sh:BlankNodeOrIRI ] ) ],
+        [ sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+            sh:in ( <http://semweb.mmlab.be/ns/ql#CSV> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        Reference formulation for RDF files is not required. If provided, it 
+        must be ql:CSV. Results of the SPARQL query are processed as tabular 
+        rows. 
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:referenceFormulation" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The query to execute on the data source.
+        Unofficially supported by RML, not in the specification.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:query is required for RDF files. Must be provided once as a string.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rml:query" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#query> ] .
+
+<http://schema.org/RMLLogicalSourceShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    A logical source is any source that is mapped to RDF triples. A logical 
+    source is a Base Source, rml:BaseSource.
+    """ ;
+    sh:ignoredProperties ( rdf:type <http://semweb.mmlab.be/ns/rml#referenceFormulation> <http://semweb.mmlab.be/ns/rml#iterator> <http://semweb.mmlab.be/ns/rml#query> <http://www.w3.org/ns/r2rml#tableName> <http://www.w3.org/ns/r2rml#sqlQuery> <http://www.w3.org/ns/r2rml#sqlVersion> ) ;
+    sh:message """
+    RML Logical Source requires one rml:source and depending on the source 
+    type: one rml:query/rr:sqlQuery, one rml:referenceFormulation and/or 
+    one rml:iterator.
+    """ ;
+    sh:name "RML Logical Source" ;
+    sh:property [ sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rml:source" ;
+            sh:path <http://semweb.mmlab.be/ns/rml#source> ] ;
+    sh:targetClass <http://semweb.mmlab.be/ns/rml#LogicalSource> ;
+    sh:targetObjectsOf <http://semweb.mmlab.be/ns/rml#logicalSource> ;
+    sh:xone ( [ sh:and ( [ sh:or ( [ sh:property [ sh:class <http://www.w3.org/ns/dcat#Dataset> ;
+                                                sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] [ sh:property [ sh:nodeKind sh:Literal ;
+                                                sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] ) ;
+                            sh:property [ sh:in ( <http://semweb.mmlab.be/ns/ql#JSONPath> <http://semweb.mmlab.be/ns/ql#XPath> ) ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ] ] <http://schema.org/JSONOrXMLFileShape> ) ] [ sh:and ( sh:or ( [ sh:property [ sh:nodeKind sh:Literal ;
+                                        sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] [ sh:property [ sh:class <http://www.w3.org/ns/csvw#Table> ;
+                                        sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] [ sh:property [ sh:class <http://www.w3.org/ns/dcat#Dataset> ;
+                                        sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] ) <http://schema.org/CSVFileShape> ) ] [ sh:and ( [ sh:or ( [ sh:property [ sh:class <http://www.w3.org/ns/dcat#Dataset> ;
+                                                sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] [ sh:property [ sh:nodeKind sh:Literal ;
+                                                sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] ) ;
+                            sh:property [ sh:minCount 1 ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#query> ] ] <http://schema.org/RDFFileShape> ) ] [ sh:and ( [ sh:property [ sh:class <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#Database> ;
+                                    sh:nodeKind sh:BlankNodeOrIRI ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] <http://schema.org/RDBShape> ) ] [ sh:and ( [ sh:property [ sh:class <http://www.w3.org/ns/sparql-service-description#Service> ;
+                                    sh:nodeKind sh:BlankNodeOrIRI ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#source> ] ] <http://schema.org/SPARQLEndpointShape> ) ] ) .
+
+<http://schema.org/RRObjectMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents an object map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rr:ObjectMap" ;
+    sh:property [ sh:description """
+        An IRI indicating whether subject or object generated using the 
+        value from column name specified for rr:column should be an IRI 
+        reference, blank node, or a literal. 
+        """ ;
+            sh:in ( <http://www.w3.org/ns/r2rml#IRI> <http://www.w3.org/ns/r2rml#BlankNode> <http://www.w3.org/ns/r2rml#Literal> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:termType must be either rr:IRI, rr:BlankNode or rr:Literal for
+        a rr:ObjectMap.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#termType> ],
+        [ sh:description """
+        rr:language and rr:datatype may not be provided at the same time.
+        """ ;
+            sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:name "rr:language/rr:datatype" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#language> <http://www.w3.org/ns/r2rml#datatype> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        Specified the language for the object component for the generated 
+        triple from a logical table row or iterator.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:language must be a valid language tag according to BCP47 and may 
+        only be provided once as string.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:language" ;
+            sh:path <http://www.w3.org/ns/r2rml#language> ;
+            sh:pattern "^((?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?:([A-Za-z]{2,3}(-(?:[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4})(-(?:[A-Za-z]{4}))?(-(?:[A-Za-z]{2}|[0-9]{3}))?(-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?:[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?:x(-[A-Za-z0-9]{1,8})+))?)|(?:x(-[A-Za-z0-9]{1,8})+))$" ],
+        [ sh:description """
+        Specifies the datatype of the object component for the generated triple
+        from a logical table row or iterator.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:datatype may only be provided once as an IRI.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:datatype" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#datatype> ],
+        [ sh:description """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:template/rr:column/rr:constant/rml:reference" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#template> <http://www.w3.org/ns/r2rml#column> <http://www.w3.org/ns/r2rml#constant> <http://semweb.mmlab.be/ns/rml#reference> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+            sh:message """
+        rr:template must be a string.
+        """ ;
+            sh:name "rr:template" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#template> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        Name of a column in the logical table. When generating RDF triples from
+        a logical table row, value from the specified column is used as the 
+        subject, predicate, or object (based upon the specific domain).
+        """ ;
+            sh:message """
+        rr:column must be a string.
+        """ ;
+            sh:name "rr:column" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#column> ],
+        [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:name "rr:constant" ;
+            sh:path <http://www.w3.org/ns/r2rml#constant> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A reference rml:reference is used to refer to a column in case of 
+        databases, a record in case of CSV or TSV data source, an element in 
+        case of XML data source, an object in case of a JSON data source, etc.
+
+        A reference must be a valid identifier, considering the reference 
+        formulation (rml:referenceFormulation) specified. The reference can be
+        an absolute path, or a path relative to the iterator specified at the 
+        logical source. 
+        """ ;
+            sh:message """
+        rml:reference must be a string.
+        """ ;
+            sh:name "rml:reference" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#reference> ] .
+
+<http://schema.org/RRPredicateMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents a predicate map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rr:PredicateMap" ;
+    sh:property [ sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified for rr:column should be an IRI reference, 
+        blank node, or a literal.
+        """ ;
+            sh:in ( <http://www.w3.org/ns/r2rml#IRI> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:termType must be either rr:IRI for an rr:PredicateMap.
+        May only be provided once.
+        """ ;
+            sh:name "rr:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#termType> ],
+        [ sh:description """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:template/rr:column/rr:constant/rml:reference" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#template> <http://www.w3.org/ns/r2rml#column> <http://www.w3.org/ns/r2rml#constant> <http://semweb.mmlab.be/ns/rml#reference> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+            sh:message """
+        rr:template must be a string.
+        """ ;
+            sh:name "rr:template" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#template> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        Name of a column in the logical table. When generating RDF triples from
+        a logical table row, value from the specified column is used as the 
+        subject, predicate, or object (based upon the specific domain).
+        """ ;
+            sh:message """
+        rr:column must be a string.
+        """ ;
+            sh:name "rr:column" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#column> ],
+        [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:message """
+        rr:constant must be an IRI.
+        """ ;
+            sh:name "rr:constant" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#constant> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A reference rml:reference is used to refer to a column in case of 
+        databases, a record in case of CSV or TSV data source, an element in 
+        case of XML data source, an object in case of a JSON data source, etc.
+
+        A reference must be a valid identifier, considering the reference 
+        formulation (rml:referenceFormulation) specified. The reference can be
+        an absolute path, or a path relative to the iterator specified at the 
+        logical source. 
+        """ ;
+            sh:message """
+        rml:reference must be a string.
+        """ ;
+            sh:name "rml:reference" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#reference> ] .
+
+<http://schema.org/RRPredicateObjectMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:property [ sh:description """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but 
+        not both.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but
+        not both.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:graph/rr:graphMap" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#graph> <http://www.w3.org/ns/r2rml#graphMap> ) ] ],
+        [ sh:description """
+        Specifies a GraphMap. When used with a SubjectMap element, all the RDF 
+        triples generated from a logical row will be stored in the specified 
+        named graph. Otherwise, the RDF triple generated using the 
+        (predicate, object) pair will be stored in the specified named graph.
+        """ ;
+            sh:message """
+        rr:graphMap must be either an IRI or blank node. 
+        """ ;
+            sh:name "rr:graphMap" ;
+            sh:node <http://schema.org/RRGraphMapShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#graphMap> ],
+        [ sh:description """
+        An IRI reference for use as the graph name of all triples generated 
+        with the GraphMap.
+        """ ;
+            sh:message """
+        rr:graphMap must be an IRI. 
+        """ ;
+            sh:name "rr:graph" ;
+            sh:node <http://schema.org/RRgraphShape> ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#graph> ],
+        [ sh:description """
+        Either an rr:predicate or rr:predicateMap must be provided, not both.
+        """ ;
+            sh:message """
+        Either an rr:predicate or rr:predicateMap must be provided, not both.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:predicate/rr:predicateMap" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#predicate> <http://www.w3.org/ns/r2rml#predicateMap> ) ] ],
+        [ sh:description """
+        A PredicateMap element to generate the predicate component of the 
+        (predicate, object) pair from a logical table row or iterator.
+        """ ;
+            sh:message """
+        rr:predicateMap must be an IRI or blank node and be provided once.
+        """ ;
+            sh:name "rr:predicateMap" ;
+            sh:node <http://schema.org/RRPredicateMapShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#predicateMap> ],
+        [ sh:description """
+        Specifies the predicate for the generated triple from the logical table 
+        row or iterator.
+        """ ;
+            sh:message """
+        rr:predicate must be an IRI and be provided once.
+        """ ;
+            sh:name "rr:predicate" ;
+            sh:node <http://schema.org/RRpredicateShape> ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#predicate> ],
+        [ sh:description """
+        Either an rr:object or rr:objectMap must be provided, not both.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Either an rr:object or rr:objectMap must be provided, not both.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:object/rr:objectMap" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#object> <http://www.w3.org/ns/r2rml#objectMap> ) ] ],
+        [ sh:description """
+        An ObjectMap element to generate the object component of the 
+        (predicate, object) pair from a logical table row or iterator.
+        """ ;
+            sh:message """
+        rr:objectMap must be an IRI or blank node and be provided once.
+        """ ;
+            sh:name "rr:objectMap" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#objectMap> ;
+            sh:xone ( [ sh:node <http://schema.org/RRObjectMapShape> ] [ sh:node <http://schema.org/RRRefObjectMapShape> ] ) ],
+        [ sh:description """
+        Specifies the object for the generated triple from the logical table 
+        row or iterator.
+        """ ;
+            sh:message """
+        rr:object must be an IRI and be provided once.
+        """ ;
+            sh:name "rr:object" ;
+            sh:node <http://schema.org/RRobjectShape> ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#object> ] .
+
+<http://schema.org/RRRefObjectMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents a reference object map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:RefObjectMap must specify a rr:parentTriplesMap and zero or more 
+    rr:joinConditions.
+    """ ;
+    sh:name "rr:RefObjectMap" ;
+    sh:property [ sh:class <http://www.w3.org/ns/r2rml#TriplesMap> ;
+            sh:description """
+        Specifies the TriplesMap element corresponding to the parent logical 
+        table of the foreign key constraint.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:parentTriplesMap may only be provided once and must be an IRI or 
+        blank node referring to a rr:TriplesMap.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:parentTriplesMap" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#parentTriplesMap> ],
+        [ sh:closed true ;
+            sh:description """
+        Specifies the join condition for joining the child logical table with 
+        the parent logical table of the foreign key constraint.
+        """ ;
+            sh:message """
+        rr:joinCondition must specify an rr:parent and rr:child.
+        """ ;
+            sh:name "rr:joinCondition" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#joinCondition> ;
+            sh:property [ sh:datatype xsd:string ;
+                    sh:description """
+            Names a column in the parent table of a join.
+            """ ;
+                    sh:maxCount 1 ;
+                    sh:message """
+            rr:parent must be string and only occur once.
+            """ ;
+                    sh:minCount 1 ;
+                    sh:name "rr:parent" ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path <http://www.w3.org/ns/r2rml#parent> ],
+                [ sh:datatype xsd:string ;
+                    sh:description """
+            Names a column in the child table of a join.
+            """ ;
+                    sh:maxCount 1 ;
+                    sh:message """
+            rr:child must be string and only occur once.
+            """ ;
+                    sh:minCount 1 ;
+                    sh:name "rr:child" ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path <http://www.w3.org/ns/r2rml#child> ] ] .
+
+<http://schema.org/RRSubjectMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents a subject map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:subjectMap requires one rr:template or one rr:column or 1 rr:constant or
+    one rml:reference.
+    """ ;
+    sh:name "rr:SubjectMap" ;
+    sh:property [ sh:description """
+        The subject value generated for a logical table row will be asserted 
+        as an instance of this RDFS class.
+        """ ;
+            sh:message """
+        rr:class must be an IRI and may be specified multiple times.
+        """ ;
+            sh:name "rr:class" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#class> ],
+        [ sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified for rr:column should be an IRI reference, 
+        or blank node.
+        """ ;
+            sh:in ( <http://www.w3.org/ns/r2rml#IRI> <http://www.w3.org/ns/r2rml#BlankNode> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:termType must be either rr:IRI or rr:BlankNode for an rr:SubjectMap.
+        May only be provided once.
+        """ ;
+            sh:name "rr:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#termType> ],
+        [ sh:description """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but 
+        not both.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but
+        not both.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rr:graph/rr:graphMap" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#graph> <http://www.w3.org/ns/r2rml#graphMap> ) ] ],
+        [ sh:description """
+        Specifies a GraphMap. When used with a SubjectMap element, all the RDF 
+        triples generated from a logical row will be stored in the specified 
+        named graph. Otherwise, the RDF triple generated using the 
+        (predicate, object) pair will be stored in the specified named graph.
+        """ ;
+            sh:message """
+        rr:graphMap must be either an IRI or blank node. 
+        """ ;
+            sh:name "rr:graphMap" ;
+            sh:node <http://schema.org/RRGraphMapShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://www.w3.org/ns/r2rml#graphMap> ],
+        [ sh:description """
+        An IRI reference for use as the graph name of all triples generated 
+        with the GraphMap.
+        """ ;
+            sh:message """
+        rr:graphMap must be an IRI. 
+        """ ;
+            sh:name "rr:graph" ;
+            sh:node <http://schema.org/RRgraphShape> ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#graph> ],
+        [ sh:description """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:template/rr:column/rr:constant/rml:reference" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#template> <http://www.w3.org/ns/r2rml#column> <http://www.w3.org/ns/r2rml#constant> <http://semweb.mmlab.be/ns/rml#reference> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+            sh:message """
+        rr:template must be a string.
+        """ ;
+            sh:name "rr:template" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#template> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        Name of a column in the logical table. When generating RDF triples from
+        a logical table row, value from the specified column is used as the 
+        subject, predicate, or object (based upon the specific domain).
+        """ ;
+            sh:message """
+        rr:column must be a string.
+        """ ;
+            sh:name "rr:column" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#column> ],
+        [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:message """
+        rr:constant must be an IRI.
+        """ ;
+            sh:name "rr:constant" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#constant> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A reference rml:reference is used to refer to a column in case of 
+        databases, a record in case of CSV or TSV data source, an element in 
+        case of XML data source, an object in case of a JSON data source, etc.
+
+        A reference must be a valid identifier, considering the reference 
+        formulation (rml:referenceFormulation) specified. The reference can be
+        an absolute path, or a path relative to the iterator specified at the 
+        logical source. 
+        """ ;
+            sh:message """
+        rml:reference must be a string.
+        """ ;
+            sh:name "rml:reference" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#reference> ] .
+
+<http://schema.org/RRobjectShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An IRI reference for use as object for all the RDF triples generated from 
+    a logical table row or iterator.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rr:object" .
+
+<http://schema.org/RRpredicateShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Specifies the predicate for the generated triple from the logical table 
+    row or iterator.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:predicate must be an IRI.
+    """ ;
+    sh:name "rr:predicate" ;
+    sh:nodeKind sh:IRI .
+
+<http://schema.org/RRsubjectShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An IRI reference for use as subject for all the RDF triples generated from 
+    a logical table row or iterator.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:subject shortcut for rr:subjectMap must be an IRI or BlankNode.
+    """ ;
+    sh:name "rr:subject" ;
+    sh:nodeKind sh:BlankNodeOrIRI .
+
+<http://schema.org/SDServiceShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An RML Logical Source description for an SD Service describes how a 
+    SPARQL service must be accessed. 
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """ 
+    An RML Logical Source description for an SD Service requires exactly
+    one sd:endpoint, one sd:supportedLanguage and one sd:resultFormat 
+    properties.
+    """ ;
+    sh:name "RML Logical Source description: SD Service" ;
+    sh:property [ sh:description """
+        Relates an instance of sd:Service to a SPARQL endpoint that implements 
+        the SPARQL Protocol service (SPROT) for the service. The object of the 
+        sd:endpoint property is an IRI.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one endpoint IRI is required to access a SPARQL service.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "sd:endpoint" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/sparql-service-description#endpoint> ],
+        [ sh:description """
+        Relates an instance of sd:Service to a SPARQL language 
+        (e.g. Query and Update) that it implements.
+        """ ;
+            sh:in ( <http://www.w3.org/ns/sparql-service-description#SPARQL10Query> <http://www.w3.org/ns/sparql-service-description#SPARQL11Query> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        The supported language for a RML Logical Source: SD Service doesn't 
+        match with sd:SPARQL10Query or sd:SPARQL11Query.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "sd:supportedLanguage" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/sparql-service-description#supportedLanguage> ],
+        [ sh:description """
+        Relates an instance of sd:Service to a format that is supported for 
+        serializing query results.
+        """ ;
+            sh:in ( <http://www.w3.org/ns/formats/SPARQL_Results_XML> <http://www.w3.org/ns/formats/SPARQL_Results_JSON> <http://www.w3.org/ns/formats/SPARQL_Results_CSV> <http://www.w3.org/ns/formats/SPARQL_Results_TSV> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        The result format for a RML Logical Source: SD Service doesn't match 
+        with  format:SPARQL_Results_XML, format:SPARQL_Results_JSON, 
+        format:SPARQL_Results_CSV or format:SPARQL_Results_TSV.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "sd:resultFormat" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/sparql-service-description#resultFormat> ] ;
+    sh:targetClass <http://www.w3.org/ns/sparql-service-description#Service> .
+
+<http://schema.org/SPARQLEndpointShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:ignoredProperties ( <http://semweb.mmlab.be/ns/rml#iterator> <http://semweb.mmlab.be/ns/rml#referenceFormulation> ) ;
+    sh:or ( [ sh:and ( [ sh:property [ sh:in ( <http://semweb.mmlab.be/ns/ql#JSONPath> <http://semweb.mmlab.be/ns/ql#XPath> ) ;
+                                    sh:maxCount 1 ;
+                                    sh:minCount 1 ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ] ] [ sh:property [ sh:datatype xsd:string ;
+                                    sh:maxCount 1 ;
+                                    sh:minCount 1 ;
+                                    sh:nodeKind sh:Literal ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#iterator> ] ] ) ] [ sh:and ( [ sh:property [ sh:in ( <http://semweb.mmlab.be/ns/ql#CSV> <http://semweb.mmlab.be/ns/ql#TSV> ) ;
+                                    sh:maxCount 1 ;
+                                    sh:minCount 0 ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#referenceFormulation> ] ] [ sh:property [ sh:datatype xsd:string ;
+                                    sh:maxCount 0 ;
+                                    sh:minCount 0 ;
+                                    sh:nodeKind sh:Literal ;
+                                    sh:path <http://semweb.mmlab.be/ns/rml#iterator> ] ] ) ] ) ;
+    sh:property [ sh:class <http://www.w3.org/ns/sparql-service-description#Service> ;
+            sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+            sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        
+        Access SPARQL endpoints requires a SD Service description.
+        """ ;
+            sh:name "rml:source" ;
+            sh:node <http://schema.org/SDServiceShape> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path <http://semweb.mmlab.be/ns/rml#source> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The query to execute on the data source.
+        rml:query is unofficially supported by RML, but not in the 
+        specification.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:query is required for querying a SPARQL endpoint.
+        Must be provided once as a string.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rml:query" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#query> ] .
+
+<http://schema.org/DCATDistributionShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    A DCAT Distribution is a specific representation of a dataset. A dataset 
+    might be available in multiple serializations that may differ in various 
+    ways, including natural language, media-type or format, schematic 
+    organization, temporal and spatial resolution, level of detail or profiles 
+    (which might specify any or all of the above). 
+    """ ;
+    sh:ignoredProperties ( rdf:type ),
+        ( rdf:type ) ;
+    sh:message """
+    A DCAT Distribution requires exactly one dcat:downloadURL property.
+    """ ;
+    sh:name "DCAT Dataset description: DCAT Distribution" ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:description """
+        The URL of the downloadable file in a given format. E.g. CSV file or 
+        RDF file. The format is indicated by the distribution's dct:format 
+        and/or dcat:mediaType.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one dcat:downloadURL is required to download the dataset.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "dcat:downloadURL" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/dcat#downloadURL> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The URL of the downloadable file in a given format. E.g. CSV file or 
+        RDF file. The format is indicated by the distribution's dct:format 
+        and/or dcat:mediaType.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one dcat:downloadURL is required to download the dataset.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "dcat:downloadURL" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/dcat#downloadURL> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        The media type of the distribution as defined by IANA.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one dcat:mediaType may be provided. If none is provided, the 
+        MIME type is guessed.
+        """ ;
+            sh:name "dcat:mediaType" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/dcat#mediaType> ] ;
+    sh:targetClass <http://www.w3.org/ns/dcat#Distribution> .
+
+<http://schema.org/RRGraphMapShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    Represents a graph map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:GraphMap must specify an rr:template, rml:reference, rr:column or
+    rr:constant with the IRI of the Named Graph.
+    """ ;
+    sh:name "rr:graphMap" ;
+    sh:property [ sh:description """
+        Exactly one rr:template, one rml:reference, one rr:constant or one rr:column is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rr:template, one rml:reference, one rr:constant or one rr:column is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rr:template/rr:constant/rml:reference/rr:column" ;
+            sh:path [ sh:alternativePath ( <http://www.w3.org/ns/r2rml#template> <http://www.w3.org/ns/r2rml#constant> <http://semweb.mmlab.be/ns/rml#reference> <http://www.w3.org/ns/r2rml#column> ) ] ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+            sh:message """
+        rr:template must be a string.
+        """ ;
+            sh:name "rr:template" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#template> ],
+        [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:message """
+        rr:constant must be an IRI.
+        """ ;
+            sh:name "rr:constant" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#constant> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A property for indicating whether a term map is an RML reference.
+        """ ;
+            sh:message """
+        rml:reference must be a string.
+        """ ;
+            sh:name "rml:reference" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://semweb.mmlab.be/ns/rml#reference> ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        A property for indicating whether a term map is an R2RML column.
+        """ ;
+            sh:message """
+        rr:column must be a string.
+        """ ;
+            sh:name "rr:column" ;
+            sh:nodeKind sh:Literal ;
+            sh:path <http://www.w3.org/ns/r2rml#column> ],
+        [ sh:description """
+        An IRI indicating whether graph generated using the value 
+        from column name specified for rr:column or an RML reference
+        should be an IRI reference or blank node.
+        """ ;
+            sh:in ( <http://www.w3.org/ns/r2rml#IRI> <http://www.w3.org/ns/r2rml#BlankNode> ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rr:termType must be either rr:IRI or rr:BlankNode for an rr:GraphMap.
+        May only be provided once.
+        """ ;
+            sh:name "rr:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path <http://www.w3.org/ns/r2rml#termType> ] .
+
+<http://schema.org/RRgraphShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An IRI reference for use as the graph name of all triples generated with 
+    the GraphMap. 
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:message """
+    rr:graph must be an IRI.
+    """ ;
+    sh:name "rr:graph" ;
+    sh:nodeKind sh:IRI .
+
+<http://schema.org/DCATDatasetShape> a sh:NodeShape ;
+    sh:closed true ;
+    sh:description """
+    An RML Logical Source description for a DCAT Dataset describes how a DCAT
+    Dataset must be accessed.
+    """ ;
+    sh:ignoredProperties ( rdf:type ),
+        ( rdf:type ) ;
+    sh:message """
+    An RML Logical Source description for a DCAT Dataset requires exactly one
+    dcat:distribution property.
+    """ ;
+    sh:name "RML Logical Source description: DCAT Dataset" ;
+    sh:property [ sh:class <http://www.w3.org/ns/dcat#Distribution> ;
+            sh:description """
+        An available distribution of the dataset.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one dcat:distribution is required to access a distribution of 
+        the data.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "dcat:distribution" ;
+            sh:node <http://schema.org/DCATDistributionShape> ;
+            sh:path <http://www.w3.org/ns/dcat#distribution> ],
+        [ sh:class <http://www.w3.org/ns/dcat#Distribution> ;
+            sh:description """
+        An available distribution of the dataset.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one dcat:distribution is required to access a distribution of 
+        the data.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "dcat:distribution" ;
+            sh:node <http://schema.org/DCATDistributionShape> ;
+            sh:path <http://www.w3.org/ns/dcat#distribution> ] ;
+    sh:targetClass <http://www.w3.org/ns/dcat#Dataset> .
+

--- a/Shapes/shapes/v1/README.md
+++ b/Shapes/shapes/v1/README.md
@@ -1,0 +1,30 @@
+# SHACL shapes for RML v1
+
+SHACL shapes for the [original RML specification](https://rml.io/specs/rml) (v1)
+These shapes were created manually, based upon the R2RML, RML, CSVW, SD,
+D2RQ, and DCAT specifications.
+
+These SHACL shapes validate:
+- R2RML Graph Map
+- R2RML Logical Table
+- R2RML Object Map
+- R2RML Predicate Map
+- R2RML Predicate Object Map
+- R2RML Subject Map
+- R2RML Triples Map
+- R2RML Reference Object Map
+- RML Logical Source
+- RML reference
+- CSVW for rml:source (CSV files)
+- SD for rml:source (SPARQL endpoints)
+- D2RQ for rml:source (RDBs)
+- DCAT Dataset & Distribution for rml:source (W3C DCAT)
+
+All these shapes can be combined into one giant shape (included as well)
+with `./generate_shape.py` to make it easier for for validating mapping
+rules with existing SHACL tools.
+
+These shapes are tested with a set of test cases and are executed by
+Github Actions. These test cases verify if required properties are
+present and verifies the cardinalities of required and optional
+properties.

--- a/Shapes/shapes/v1/csvw/dialect.ttl
+++ b/Shapes/shapes/v1/csvw/dialect.ttl
@@ -1,0 +1,263 @@
+###############################################################################
+# CSVW Table: CSVW Dialect shape                                              #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+schema:CSVWDialectShape
+    a sh:NodeShape ;
+    sh:targetClass csvw:Dialect ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'csvw:Dialect'
+    sh:name "csvw:Dialect" ;
+    sh:description """
+    Dialect description for a CSVW Table. One csvw:delimiter, one csvw:encoding,
+    one csvw:doubleQuote, one csvw:quoteChar, one csvw:escapeChar, one 
+    csvw:lineTerminators, one csvw:trim, one csvw:skipInitialSpace, one 
+    csvw:header, one csvw:headerRowCount, one csvw:skipColumns, one 
+    csvw:skipRows and one csvw:commentPrefix are optional.
+    """ ;
+    sh:message "CSVW Dialect violation" ;
+    sh:property [
+        sh:path csvw:delimiter ;
+        sh:name "csvw:delimiter" ;
+        sh:description """
+        An atomic property that sets the delimiter flag to the single provided 
+        value, which MUST be a string.
+        """ ;
+        sh:message """
+        The delimiter must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+        sh:minLength 1 ;
+        sh:maxLength 1 ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path csvw:encoding ;
+        sh:name "csvw:encoding" ;
+        sh:description """
+        An atomic property that sets the encoding flag to the single provided 
+        string value, which MUST be a defined in [encoding]. The default is 
+        "utf-8".
+
+        [encoding] https://encoding.spec.whatwg.org/
+        """ ;
+        sh:message """
+        The file encoding must match with the file encodings listed in 
+        https://encoding.spec.whatwg.org/.
+        May only be provided once.
+        """ ;
+        # Existing encoding matching, see: https://encoding.spec.whatwg.org/
+        sh:pattern "(unicode-1-1-utf-8)|(unicode11utf8)|(unicode20utf8)|(utf-8)|(utf8)|(x-unicode20utf8)|(866)|(cp866)|(csibm866)|(ibm866)|(csisolatin2)|(iso-8859-2)|(iso-ir-101)|(iso8859-2)|(iso88592)|(iso_8859-2)|(iso_8859-2:1987)|(l2)|(latin2)|(csisolatin3)|(iso-8859-3)|(iso-ir-109)|(iso8859-3)|(iso88593)|(iso_8859-3)|(iso_8859-3:1988)|(l3)|(latin3)|(csisolatin4)|(iso-8859-4)|(iso-ir-110)|(iso8859-4)|(iso88594)|(iso_8859-4)|(iso_8859-4:1988)|(l4)|(latin4)|(csisolatincyrillic)|(cyrillic)|(iso-8859-5)|(iso-ir-144)|(iso8859-5)|(iso88595)|(iso_8859-5)|(iso_8859-5:1988)|(arabic)|(asmo-708)|(csiso88596e)|(csiso88596i)|(csisolatinarabic)|(ecma-114)|(iso-8859-6)|(iso-8859-6-e)|(iso-8859-6-i)|(iso-ir-127)|(iso8859-6)|(iso88596)|(iso_8859-6)|(iso_8859-6:1987)|(csisolatingreek)|(ecma-118)|(elot_928)|(greek)|(greek8)|(iso-8859-7)|(iso-ir-126)|(iso8859-7)|(iso88597)|(iso_8859-7)|(iso_8859-7:1987)|(sun_eu_greek)|(csiso88598e)|(csisolatinhebrew)|(hebrew)|(iso-8859-8)|(iso-8859-8-e)|(iso-ir-138)|(iso8859-8)|(iso88598)|(iso_8859-8)|(iso_8859-8:1988)|(visual)|(csiso88598i)|(iso-8859-8-i)|(logical)|(csisolatin6)|(iso-8859-10)|(iso-ir-157)|(iso8859-10)|(iso885910)|(l6)|(latin6)|(iso-8859-13)|(iso8859-13)|(iso885913)|(iso-8859-14)|(iso8859-14)|(iso885914)|(csisolatin9)|(iso-8859-15)|(iso8859-15)|(iso885915)|(iso_8859-15)|(l9)|(iso-8859-16)|(cskoi8r)|(koi)|(koi8)|(koi8-r)|(koi8_r)|(koi8-ru)|(koi8-u)|(csmacintosh)|(mac)|(macintosh)|(x-mac-roman)|(dos-874)|(iso-8859-11)|(iso8859-11)|(iso885911)|(tis-620)|(windows-874)|(cp1250)|(windows-1250)|(x-cp1250)|(cp1251)|(windows-1251)|(x-cp1251)|(ansi_x3.4-1968)|(ascii)|(cp1252)|(cp819)|(csisolatin1)|(ibm819)|(iso-8859-1)|(iso-ir-100)|(iso8859-1)|(iso88591)|(iso_8859-1)|(iso_8859-1:1987)|(l1)|(latin1)|(us-ascii)|(windows-1252)|(x-cp1252)|(cp1253)|(windows-1253)|(x-cp1253)|(cp1254)|(csisolatin5)|(iso-8859-9)|(iso-ir-148)|(iso8859-9)|(iso88599)|(iso_8859-9)|(iso_8859-9:1989)|(l5)|(latin5)|(windows-1254)|(x-cp1254)|(cp1255)|(windows-1255)|(x-cp1255)|(cp1256)|(windows-1256)|(x-cp1256)|(cp1257)|(windows-1257)|(x-cp1257)|(cp1258)|(windows-1258)|(x-cp1258)|(x-mac-cyrillic)|(x-mac-ukrainian)|(chinese)|(csgb2312)|(csiso58gb231280)|(gb2312)|(gb_2312)|(gb_2312-80)|(gbk)|(iso-ir-58)|(x-gbk)|(gb18030)|(big5)|(big5-hkscs)|(cn-big5)|(csbig5)|(x-x-big5)|(cseucpkdfmtjapanese)|(euc-jp)|(x-euc-jp)|(csiso2022jp)|(iso-2022-jp)|(csshiftjis)|(ms932)|(ms_kanji)|(shift-jis)|(shift_jis)|(sjis)|(windows-31j)|(x-sjis)|(cseuckr)|(csksc56011987)|(euc-kr)|(iso-ir-149)|(korean)|(ks_c_5601-1987)|(ks_c_5601-1989)|(ksc5601)|(ksc_5601)|(windows-949)|(csiso2022kr)|(hz-gb-2312)|(iso-2022-cn)|(iso-2022-cn-ext)|(iso-2022-kr)|(replacement)|(unicodefffe)|(utf-16be)|(csunicode)|(iso-10646-ucs-2)|(ucs-2)|(unicode)|(unicodefeff)|(utf-16)|(utf-16le)|(x-user-defined)" ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path csvw:doubleQuote ;
+        sh:name "csvw:doubleQuote" ;
+        sh:description """
+        A boolean atomic property that, if `true`, sets the escape character 
+        flag to `"`.
+        """ ;
+        sh:message """
+        The doubleQuote flag must be a boolean.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:boolean ;
+    ] ;
+    sh:property [
+        sh:path csvw:quoteChar ;
+        sh:name "csvw:quoteChar" ;
+        sh:description """
+        An atomic property that sets the quote character flag to the single 
+        provided value, which must be a string or `null`.
+        """ ;
+        sh:message """
+        The quote character must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:minLength 1 ;
+        sh:maxLength 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+    sh:property [
+        sh:path csvw:escapeChar ;
+        sh:name "csvw:escapeChar" ;
+        sh:description """
+        The escape character to use when escaping special characters in the CSV
+        file.
+        Unofficially! Not supported by the CSVW specification!
+        """ ;
+        sh:message """
+        The escape character must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:minLength 1 ;
+        sh:maxLength 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ];
+    sh:property [
+        sh:path csvw:lineTerminators ;
+        sh:name "csvw:lineTerminators" ;
+        sh:description """
+        An atomic property that sets the line terminators flag to either an 
+        array containing the single provided string value, or the provided 
+        array.
+        """ ;
+        sh:message """
+        The line terminators must be a string with a length of at least 1.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:minLength 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ];
+    sh:property [
+        sh:path csvw:trim ;
+        sh:name "csvw:trim";
+        sh:description """
+        An atomic property that, if the boolean `true`, sets the trim flag to 
+        `true` and if the boolean `false` to `false`. If the value provided is 
+        a string, sets the trim flag to the provided value, which must be one 
+        of "true", "false", "start" or "end".
+        """ ;
+        sh:message """
+        Trim mode must be either a boolean or a string with value "true", 
+        "false", "start" or "end". May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        # csvw:trim can be either a boolean or string
+        sh:or (
+            [
+                sh:datatype xsd:string;
+                sh:in ("true" "false" "start" "end");
+            ]
+            [
+                sh:datatype xsd:boolean;
+                sh:in ("true"^^xsd:boolean "false"^^xsd:boolean);
+            ]
+        );
+    ];
+    sh:property [
+        sh:path csvw:skipInitialSpace ;
+        sh:name "csvw:skipInitialSpace" ;
+        sh:description """
+        A boolean atomic property that, if `true`, sets the trim flag to 
+        "start". If `false`, to `false`.
+        """ ;
+        sh:message """
+        Skip initial space flag must be a boolean. May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:boolean ;
+    ] ;
+    sh:property [
+        sh:path csvw:header ;
+        sh:name "csvw:header" ;
+        sh:description """
+        A boolean atomic property that, if `true`, sets the header row count 
+        flag to `1`, and if `false` to `0`, unless headerRowCount is provided, 
+        in which case the value provided for the header property is ignored.
+        """ ;
+        sh:message """
+        Header flag must be a boolean. May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:boolean ;
+    ] ;
+    sh:property [
+        sh:path csvw:headerRowCount ;
+        sh:name "csvw:headerRowCount" ;
+        sh:description """
+        An numeric atomic property that sets the header row count flag to the 
+        single provided value, which must be a non-negative integer.
+        """ ;
+        sh:message """
+        The header row count must be a non-negative integer. May only be 
+        provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:integer ;
+        sh:minInclusive "0"^^xsd:integer;
+    ] ;
+    sh:property [
+        sh:path csvw:skipColumns ;
+        sh:name "csvw:skipColumns";
+        sh:description """
+        An numeric atomic property that sets the `skip columns` flag to the 
+        single provided numeric value, which MUST be a non-negative integer.
+        """ ;
+        sh:message """
+        Skip columns must be a non-negative integer. May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal;
+        sh:datatype xsd:integer ;
+        sh:minInclusive "0"^^xsd:integer;
+    ] ;
+    sh:property [
+        sh:path csvw:skipRows ;
+        sh:name "csvw:skipRows";
+        sh:description """
+        An numeric atomic property that sets the `skip rows` flag to the single 
+        provided numeric value, which MUST be a non-negative integer.
+        """ ;
+        sh:message """
+        Skip rows must be a non-negative integer. May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal;
+        sh:datatype xsd:integer ;
+        sh:minInclusive "0"^^xsd:integer;
+    ] ;
+    sh:property [
+        sh:path csvw:commentPrefix ;
+        sh:name "csvw:commentPrefix" ;
+        sh:description """
+        An atomic property that sets the comment prefix flag to the single 
+        provided value, which MUST be a string.
+        """ ;
+        sh:message """
+        Comment prefix must be a string and its length must be exactly 1.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:minLength 1 ;
+        sh:maxLength 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+.

--- a/Shapes/shapes/v1/csvw/table.ttl
+++ b/Shapes/shapes/v1/csvw/table.ttl
@@ -1,0 +1,84 @@
+###############################################################################
+# RML Logical Source: CSVW Table shape                                        #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:CSVWTableShape
+    a sh:NodeShape ;
+    sh:targetClass csvw:Table ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'csvw:Table'
+    sh:name "RML Logical Source: CSVW Table" ;
+    sh:description """
+    An RML Logical Source: CSVW Table describes how a CSV needs to be accessed
+    and processed.
+    """ ;
+    sh:message """
+    An RML Logical Source description for a CSVW Table requires exactly one
+    csvw:url and optionally one csvw:dialect or one csvw:tableSchema.
+    """ ;
+    
+    # csvw:url
+    sh:property [
+        sh:path csvw:url ;
+        sh:name "csvw:url" ;
+        sh:description """
+        This link property gives the single URL of the CSV file that the table 
+        is held in, relative to the location of the metadata document. 
+        """ ;
+        sh:message """
+        The csvw:url must be a string URL pointing to the location of the CSV 
+        file.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # csvw:dialect
+    sh:property [
+        sh:path csvw:dialect ;
+        sh:name "csvw:dialect" ;
+        sh:description """
+        An object property that provides a single dialect description. If 
+        provided, dialect provides hints to processors about how to parse the 
+        referenced files to create tabular data models for the tables in the 
+        group.
+        """ ;
+        sh:message """
+        A single csvw:Dialect description is expected. The dialect description 
+        is optional and falls back to the default dialect specified in the CSVW
+        specification.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:CSVWDialectShape ;
+    ] ;
+
+    # csvw:tableSchema
+    sh:property [
+        sh:path csvw:tableSchema ;
+        sh:name "csvw:tableSchema" ;
+        sh:description """
+        An object property that provides a single schema, used as the default 
+        for all the tables in the group.
+        """ ;
+        sh:message """
+        A single csvw:TableSchema description is expected. The table schema 
+        description is optional and fallsback to extracting the CSV header from
+        the CSV file itself. 
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:CSVWTableSchemaShape ;
+    ] ;
+.

--- a/Shapes/shapes/v1/csvw/table_schema.ttl
+++ b/Shapes/shapes/v1/csvw/table_schema.ttl
@@ -1,0 +1,88 @@
+###############################################################################
+# CSVW Table: CSVW TableSchema shape                                          #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix dash: <http://datashapes.org/dash#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+schema:CSVWTableSchema
+    a sh:NodeShape ;
+    sh:targetClass csvw:TableSchema ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'csvw:TableSchema'
+    sh:name "csvw:TableSchema" ;
+    sh:description """
+    An object property that provides a single schema description, used as the 
+    default for all the tables in the group.
+    """ ;
+    sh:message """
+    TableSchema description for a CSVW Table. 1 csvw:columns is required.
+    """ ;
+
+    # csvw:columns
+    sh:property [
+        sh:path csvw:columns ;
+        sh:node dash:ListShape ;  # rdf:List shape
+        sh:name "csvw:columns" ; 
+        sh:description """
+        csvw:column with string values interpreted as identifier with array 
+        values interpreted as rdf:List.
+        """ ;
+        sh:message """
+        At least one CSVW Column is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+
+        # rdf:List
+        sh:property [
+            sh:closed "true"^^xsd:boolean ;
+            sh:path ([sh:zeroOrMorePath rdf:rest] rdf:first) ;  # rdf:List
+            sh:minCount 1 ;
+
+            # rdf:List element: csvw:name
+            sh:property [
+                sh:path csvw:name ;
+                sh:name "csvw:name" ;
+                sh:description """
+                An atomic property that gives a single canonical name for the 
+                column. The value of this property becomes the name annotation 
+                for the described column.
+                May only be provided once.
+                """ ;
+                sh:message """
+                csvw:name must be a string and is required.
+                """ ;
+                sh:maxCount 1 ;
+                sh:minCount 1 ;
+                sh:minLength 1 ;
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;
+            ] ;
+
+            # rdf:List element: csvw:null
+            sh:property [
+                sh:path csvw:null ;
+                sh:name "csvw:null" ;
+                sh:description """
+                An atomic property giving the string or strings used for null 
+                values within the data. If the string value of the cell is 
+                equal to any one of these values, the cell value is `null`.
+                """ ;
+                sh:message """
+                csvw:null must be a string and is optional.
+                May only be provided once.
+                """ ;
+                sh:maxCount 1 ;
+                sh:minCount 0 ;
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;
+            ] ;
+        ] ;
+    ] ;
+.

--- a/Shapes/shapes/v1/d2rq/database.ttl
+++ b/Shapes/shapes/v1/d2rq/database.ttl
@@ -1,0 +1,104 @@
+###############################################################################
+# RML Logical Source: D2RQ Database shape                                     #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+schema:D2RQDatabaseShape
+    a sh:NodeShape ;
+    sh:targetClass d2rq:Database ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'd2rq:Database'
+    sh:name "RML Logical Source description: D2RQ Database" ;
+    sh:description """
+    An RML Logical Source: D2RQ Database describes how a relational database 
+    needs to be accessed.
+    """ ;
+    sh:message """
+    An RML Logical Source description for a D2RQ Database requires exactly
+    one d2rq:jdbcDSN, one d2rq:jdbcDriver. d2rq:username and d2rq:password are
+    optional.
+    """ ;
+
+    # If password is provided, require also an username
+    sh:or ( 
+        # Username must be provided, if password is provided
+        [sh:and ([sh:path d2rq:username ; sh:minCount 1 ;]
+                 [sh:path d2rq:password ; sh:minCount 1 ;])]
+        # Username is may be provided or left out, without a password
+        [sh:and ([sh:path d2rq:username ; sh:minCount 0 ;]
+                 [sh:path d2rq:password ; sh:maxCount 0 ;])]
+    ) ;
+
+    # d2rq:jdbcDSN
+    sh:property [
+        sh:path d2rq:jdbcDSN ;
+        sh:name "d2rq:jdbcDSN" ;
+        sh:description """
+        The JDBC database URL.
+        """ ;
+        sh:message """
+        The JDBC database URL must be a string of the form: 
+        'jdbc:{subprotocol}:{subname}://{hostname}:{port}/{dbname}'
+        and may only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+    
+    # d2rq:jdbcDriver
+    sh:property [
+        sh:path d2rq:jdbcDriver ;
+        sh:name "d2rq:jdbcDriver" ;
+        sh:description """
+        The JDBC driver class name for the database. Used together with 
+        d2rq:jdbcDSN.
+        """ ;
+        sh:message """
+        The JDBC driver for the database must be specified.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # d2rq:username
+    sh:property [
+        sh:path d2rq:username ;
+        sh:name "d2rq:username" ;
+        sh:description """
+        A username if required by the database.
+        """ ;
+        sh:message """
+        The username for the database must be a string. 
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # d2rq:password
+    sh:property [
+        sh:path d2rq:password ;
+        sh:name "d2rq:password" ;
+        sh:description """
+        A password if required by the database.
+        """ ;
+        sh:message """
+        The password for the database must be a string. 
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ];
+.

--- a/Shapes/shapes/v1/dcat/dataset.ttl
+++ b/Shapes/shapes/v1/dcat/dataset.ttl
@@ -1,0 +1,45 @@
+###############################################################################
+# RML Logical Source: DCAT Dataset shape                                      #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# RML Logical Source: DCAT Dataset
+schema:DCATDatasetShape
+    a sh:NodeShape ;
+    sh:targetClass dcat:Dataset ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'dcat:Dataset'
+    sh:name "RML Logical Source description: DCAT Dataset" ;
+    sh:description """
+    An RML Logical Source description for a DCAT Dataset describes how a DCAT
+    Dataset must be accessed.
+    """ ;
+    sh:message """
+    An RML Logical Source description for a DCAT Dataset requires exactly one
+    dcat:distribution property.
+    """ ;
+
+    # dcat:distribution
+    sh:property [
+        sh:path dcat:distribution ;
+        sh:name "dcat:distribution" ;
+        sh:description """
+        An available distribution of the dataset.
+        """ ;
+        sh:message """
+        Exactly one dcat:distribution is required to access a distribution of 
+        the data.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:class dcat:Distribution ;  # Must be a dcat:Distribution
+        sh:node schema:DCATDistributionShape ;  # dcat/distribution.ttl
+    ];
+.

--- a/Shapes/shapes/v1/dcat/distribution.ttl
+++ b/Shapes/shapes/v1/dcat/distribution.ttl
@@ -1,0 +1,63 @@
+###############################################################################
+# RML Logical Source: DCAT Distribution shape                                 #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# DCAT Dataset: DCAT Distribution
+schema:DCATDistributionShape
+    a sh:NodeShape ;
+    sh:targetClass dcat:Distribution ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'dcat:Distribution'
+    sh:name "DCAT Dataset description: DCAT Distribution" ;
+    sh:description """
+    A DCAT Distribution is a specific representation of a dataset. A dataset 
+    might be available in multiple serializations that may differ in various 
+    ways, including natural language, media-type or format, schematic 
+    organization, temporal and spatial resolution, level of detail or profiles 
+    (which might specify any or all of the above). 
+    """ ;
+    sh:message """
+    A DCAT Distribution requires exactly one dcat:downloadURL property.
+    """ ;
+
+    # dcat:downloadURL
+    sh:property [
+        sh:path dcat:downloadURL ;
+        sh:name "dcat:downloadURL" ;
+        sh:description """
+        The URL of the downloadable file in a given format. E.g. CSV file or 
+        RDF file. The format is indicated by the distribution's dct:format 
+        and/or dcat:mediaType.
+        """ ;
+        sh:message """
+        Exactly one dcat:downloadURL is required to download the dataset.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # dcat:mediaType
+    sh:property [
+        sh:path dcat:mediaType ;
+        sh:name "dcat:mediaType" ;
+        sh:description """
+        The media type of the distribution as defined by IANA.
+        """ ;
+        sh:message """
+        Exactly one dcat:mediaType may be provided. If none is provided, the 
+        MIME type is guessed.
+        """ ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+.

--- a/Shapes/shapes/v1/generate_shape.py
+++ b/Shapes/shapes/v1/generate_shape.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+from os import path
+from glob import glob
+from rdflib import Graph
+from rdflib.plugins.serializers.turtle import TurtleSerializer
+from rdflib import plugin
+from rdflib.term import URIRef
+
+SUBSHAPE_FORMAT = 'turtle'
+SUBSHAPE_GLOB_PATTERN = '**/*.ttl'
+
+
+class TurtleWithPrefixes(TurtleSerializer):
+    """
+    A turtle serializer that always emits prefixes
+    Workaround for https://github.com/RDFLib/rdflib/issues/1048
+    """
+    roundtrip_prefixes = True  # Undocumented, forces to write all prefixes
+
+
+class ShapeGenerator:
+    """
+    Generates a complete SHACL shape of all the SHACL subshapes.
+    Useful for using the shapes in the shacl.org Playground.
+    """
+    def __init__(self, glob_pattern: str, rdf_format: str,
+                 destination: str) -> None:
+        self._glob_pattern: str = glob_pattern
+        self._rdf_format: str = rdf_format
+        self._destination: str = destination
+        self._shape = Graph()
+        # Register TurtleWithPrefixes serializer as 'tortoise' format
+        plugin.register('tortoise',
+                        plugin.Serializer,
+                        'generate_shape',
+                        'TurtleWithPrefixes')
+
+    def generate(self) -> None:
+        """
+        Generate a full shape from the sub shapes.
+        """
+        print('Reading subshapes:')
+        for sub_shape in glob(self._glob_pattern):
+            print(f"\t{sub_shape}")
+            self._shape += Graph().parse(sub_shape, format=self._rdf_format)
+
+        print(f'Writing shape to {self._destination}')
+        self._shape.namespace_manager.bind('sh', URIRef('http://www.w3.org/ns/shacl#'))
+        self._shape.serialize(destination=self._destination, format='tortoise')
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(description='Generate a complete SHACL shape '
+                                'from the subshapes.')
+    p.add_argument('destination', type=str, help='Location to write the '
+                   'complete SHACL shape as Turtle.')
+    # Arguments parsing
+    args = p.parse_args()
+    if not path.exists(args.destination):
+        print(f'{args.destination} file path does not exist!')
+        sys.exit(1)
+
+    if path.isdir(args.destination):
+        args.destination = path.join(args.destination, 'rml_rules_shape.ttl')
+
+    # Generate shape
+    generator = ShapeGenerator(SUBSHAPE_GLOB_PATTERN, SUBSHAPE_FORMAT,
+                               args.destination)
+    generator.generate()

--- a/Shapes/shapes/v1/rml/logical_source.ttl
+++ b/Shapes/shapes/v1/rml/logical_source.ttl
@@ -1,0 +1,742 @@
+###############################################################################
+# RML Logical Source shape                                                    #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RMLLogicalSourceShape
+    a sh:NodeShape ;
+    sh:targetObjectsOf rml:logicalSource ;  # Object of rr:TriplesMap
+    sh:targetClass rml:LogicalSource ;  # Used as a class
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    # Already targets 'rml:logicalSource'
+    # Ignores rml:referenceFormulation, rml:iterator and rml:query
+    # since they are validated depending on the type of source
+    sh:ignoredProperties (rdf:type
+                          rml:referenceFormulation
+                          rml:iterator
+                          rml:query
+                          rr:tableName
+                          rr:sqlQuery
+                          rr:sqlVersion) ;
+    sh:name "RML Logical Source" ;
+    sh:description """
+    A logical source is any source that is mapped to RDF triples. A logical 
+    source is a Base Source, rml:BaseSource.
+    """ ;
+    sh:message """
+    RML Logical Source requires one rml:source and depending on the source 
+    type: one rml:query/rr:sqlQuery, one rml:referenceFormulation and/or 
+    one rml:iterator.
+    """ ;
+
+    # rml:source
+    sh:property [
+        sh:path rml:source ;
+        sh:name "rml:source" ;
+        sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+        sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ; 
+
+    # Source specific rml:iterator and rml:referenceFormulation
+    # Depending on various factors, the right shape is chosen during validation
+    sh:xone (
+    # JSON/XML file
+        [
+            sh:and (
+                [
+                    # DCAT Dataset or local file
+                    sh:or (
+                        [
+                            sh:property [
+                                sh:path rml:source ;
+                                sh:class dcat:Dataset ;
+                            ] ;
+                        ]
+                        [
+                            sh:property [
+                                sh:path rml:source ;
+                                sh:nodeKind sh:Literal ;
+                            ] ;
+                        ]
+                    );
+                    # Must have rml:referenceFormulation since default is
+                    # tabular row
+                    sh:property [
+                        sh:path rml:referenceFormulation ;
+                        sh:in (ql:JSONPath ql:XPath) ;
+                    ] ;
+                ]
+                schema:JSONOrXMLFileShape
+            )
+        ]
+        # CSV file
+        [
+            sh:and (
+                # DCAT Dataset, CSVW Table or local file
+                sh:or(
+                    [
+                        sh:property [
+                            sh:path rml:source ;
+                            sh:nodeKind sh:Literal ;
+                        ] ;
+                    ]
+                    [
+                        sh:property [
+                            sh:path rml:source ;
+                            sh:class csvw:Table ;
+                        ] ;
+                    ]
+                    [
+                        sh:property [
+                            sh:path rml:source ;
+                            sh:class dcat:Dataset ;
+                        ] ;
+                    ]
+                )
+                schema:CSVFileShape
+            )
+        ]
+        # RDF file
+        [
+            sh:and (
+                [
+                    # DCAT Dataset or local file
+                    sh:or (
+                        [
+                            sh:property [
+                                sh:path rml:source ; 
+                                sh:class dcat:Dataset ;
+                            ] ;
+                        ]
+                        [
+                            sh:property [
+                                sh:path rml:source ;
+                                sh:nodeKind sh:Literal ;
+                            ] ;
+                        ]
+                    );
+                    # Must have rml:referenceFormulation since default is
+                    # tabular row
+                    sh:property [
+                        sh:path rml:query ;
+                        sh:minCount 1 ;
+                    ] ;
+               ] 
+               schema:RDFFileShape
+           )
+        ]
+        # RDB
+        [
+            sh:and (
+                # D2RQ Database
+                [
+                    sh:property [
+                        sh:path rml:source ;
+                        sh:class d2rq:Database ;
+                        sh:nodeKind sh:BlankNodeOrIRI ;
+                    ] ;
+                ]
+                schema:RDBShape
+            )
+        ]
+        # SPARQL endpoint
+        [
+            sh:and (
+                # SD Service
+                [
+                    sh:property [
+                        sh:path rml:source ;
+                        sh:class sd:Service ;
+                        sh:nodeKind sh:BlankNodeOrIRI ;
+                    ] ;
+                ]
+                schema:SPARQLEndpointShape
+            ) 
+        ]
+    );
+.
+
+
+schema:JSONOrXMLFileShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+
+    # rml:source
+    sh:property [
+        sh:path rml:source ;
+        sh:name "rml:source" ;
+        sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+        sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        """ ;
+        sh:xone (
+            # Literal as backwards compatiblity with previous RML versions
+            [   
+                # Local JSON or XML file path
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;
+            ]
+            # RML spec requires URI for rml:source
+            [ 
+                # dcat:Dataset description
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:class dcat:Dataset ;
+                sh:node schema:DCATDatasetShape ;
+            ]
+        ) ;
+    ] ;
+
+    # rml:referenceFormulation
+    sh:property [
+        sh:path rml:referenceFormulation ;
+        sh:name "rml:referenceFormulation" ;
+        sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+        sh:message """
+        Reference formulation for XML or JSON files must be either ql:JSONPath
+        or ql:XPath.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:in (ql:JSONPath ql:XPath) ;
+    ] ;
+
+    # rml:iterator
+    sh:property [
+        sh:path rml:iterator ;
+        sh:name "rml:iterator" ;
+        sh:description """
+        The logical iterator (rml:iterator) defines the iteration loop used to 
+        map the data of the input source.  
+        """ ;
+        sh:message """
+        rml:iterator is required to iterate over the data source. May only be
+        provided once as a string.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+.
+
+
+schema:CSVFileShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+
+    # rml:source
+    sh:property [
+        sh:path rml:source ;
+        sh:name "rml:source" ;
+        sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+        sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+
+        Locating CSV files is possible using a DCAT dataset description, 
+        a CSVW Table description or a file path to a local file.
+        """ ;
+
+        sh:xone (
+            # Literal as backwards compatiblity with previous RML versions
+            [   
+                # Local CSV file path
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;
+            ]
+            # RML spec requires URI for rml:source
+            [ 
+                # csvw:Table description
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:class csvw:Table ;
+                sh:node schema:CSVWTableShape ;
+            ]
+            [ 
+                # dcat:Dataset description
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:class dcat:Dataset ;
+                sh:node schema:DCATDatasetShape ;
+            ]
+        ) ;
+
+    ] ;
+
+
+    # rml:referenceFormulation
+    sh:property [
+        sh:path rml:referenceFormulation ;
+        sh:name "rml:referenceFormulation" ;
+        sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+        sh:message """
+        Reference formulation for CSV files must be ql:CSV.
+        TSV files must use ql:TSV. Providing rml:referenceFormulation for 
+        tabular data is optional.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:in (ql:CSV ql:TSV) ;
+    ] ;
+.
+
+schema:RDFFileShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+
+    # rml:source
+    sh:property [
+        sh:path rml:source ;
+        sh:name "rml:source" ;
+        sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+        sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        
+        Locating RDF files is possible using a DCAT dataset description or a 
+        file path to a local file.
+        """ ;
+        sh:xone (
+            # Literal as backwards compatiblity with previous RML versions
+            [   
+                # Local RDF file path
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;
+            ]
+            # RML spec requires URI for rml:source
+            [ 
+                # dcat:Dataset description
+                sh:nodeKind sh:BlankNodeOrIRI ;
+                sh:class dcat:Dataset ;
+                sh:node schema:DCATDatasetShape ;
+            ]
+        ) ;
+    ] ;
+
+    # rml:referenceFormulation
+    sh:property [
+        sh:path rml:referenceFormulation ;
+        sh:name "rml:referenceFormulation" ;
+        sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+        # Subject to change, this is only to test my and Thomas' research ideas.
+        sh:message """
+        Reference formulation for RDF files is not required. If provided, it 
+        must be ql:CSV. Results of the SPARQL query are processed as tabular 
+        rows. 
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:in (ql:CSV) ;
+    ] ;
+
+    # rml:query
+    sh:property [
+        sh:path rml:query ;
+        sh:name "rml:query" ;
+        sh:description """
+        The query to execute on the data source.
+        Unofficially supported by RML, not in the specification.
+        """ ;
+        sh:message """
+        rml:query is required for RDF files. Must be provided once as a string.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+.
+
+
+schema:SPARQLEndpointShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rml:iterator rml:referenceFormulation) ;  # Optional properties
+
+    # rml:source
+    sh:property [
+        sh:path rml:source ;
+        sh:name "rml:source" ;
+        sh:description """
+        The source (rml:source) locates the input data source. It is a URI
+        that represents the data source where the data source is.
+        
+        Note: A literal as rml:source is still supported for compatibility with 
+        previous versions of RML.
+        """ ;
+        sh:message """
+        rml:source must be provided to locate the data source. rml:source must 
+        be provided exactly once as an URI or Literal for backwards 
+        compatiblity with previous versions of RML.
+        
+        Access SPARQL endpoints requires a SD Service description.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class sd:Service ;
+        sh:node schema:SDServiceShape ;
+    ] ;
+
+    # rml:query
+    sh:property [
+        sh:path rml:query ;
+        sh:name "rml:query" ;
+        sh:description """
+        The query to execute on the data source.
+        rml:query is unofficially supported by RML, but not in the 
+        specification.
+        """ ;
+        sh:message """
+        rml:query is required for querying a SPARQL endpoint.
+        Must be provided once as a string.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+    
+    # Require rml:iterator if rml:referenceFormulation is ql:JSONPath or ql:XPath
+    sh:or (
+        [
+        sh:and(
+        [
+            sh:property [ 
+                sh:path rml:referenceFormulation ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+                sh:in (ql:JSONPath ql:XPath) ;
+            ] ;
+        ]
+        [
+            sh:property [
+                sh:path rml:iterator ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;  
+            ] ;
+        ]
+        ) ;
+        ]
+        [
+            sh:and(
+        [
+            sh:property [ 
+                sh:path rml:referenceFormulation ;
+                sh:minCount 0 ;
+                sh:maxCount 1 ;
+                sh:in (ql:CSV ql:TSV) ;
+            ] ;
+        ]
+        [
+            sh:property [
+                sh:path rml:iterator ;
+                sh:minCount 0 ;
+                sh:maxCount 0 ;
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:string ;  
+            ] ;
+        ]
+        ) ;
+        ]
+    )
+.
+
+
+schema:RDBShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+
+    # rml:source
+    sh:property [
+        sh:path rml:source ;
+        sh:name "rml:source" ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:class d2rq:Database ;
+
+        # d2rq:jdbcDSN
+        sh:property [
+            sh:path d2rq:jdbcDSN ;
+            sh:name "D2RQ jdbc DSN" ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+        ] ;
+
+        # d2rq:jdbcDriver
+        sh:property [
+            sh:path d2rq:jdbcDriver ;
+            sh:name "D2RQ jdbc Driver" ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+        ] ;
+
+        # d2rq:username
+        sh:property [
+            sh:path d2rq:username ;
+            sh:name "D2RQ username" ;
+            sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+        ] ;
+
+        # d2rq:password
+        sh:property [
+            sh:path d2rq:password ;
+            sh:name "D2RQ password" ;
+            sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+        ] ;
+    ] ;
+
+    # rr:sqlVersion
+    sh:property [
+        sh:path rr:sqlVersion ;
+        sh:name "rr:sqlVersion" ;
+        sh:description """
+
+        """ ;
+        sh:message """
+        rr:sqlVersion must be rr:SQL2008. Providing rr:sqlVersion is optional.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:in (rr:SQL2008) ; # Only support for SQL 2008 at the moment
+    ] ;
+
+    # rml:query/rr:tableName/rr:sqlQuery must occur only once
+    sh:property [
+        sh:name "rml:query/rr:sqlQuery/rr:tableName" ;
+        sh:description """
+        Exactly one rml:query or one rr:sqlQuery or one rr:tableName must be 
+        provided to access the relational database.
+        """ ;
+        sh:path [sh:alternativePath (rml:query rr:sqlQuery rr:tableName)] ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ];
+
+    # rr:sqlQuery
+    sh:property [
+        sh:path rr:sqlQuery ;
+        sh:name "rr:sqlQuery" ;
+        sh:description """
+        An R2RML view is a logical table whose contents are the result of 
+        executing a SQL query against the input database. It is represented by 
+        a resource that has exactly one rr:sqlQuery property, whose value is a 
+        literal with a lexical form that is a valid SQL query.
+        """ ;
+        sh:message """
+        rr:sqlQuery is required for querying a relational database. 
+        Must be provided once as a string.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rml:query
+    sh:property [
+        sh:path rml:query ;
+        sh:name "rml:query" ;
+        sh:description """
+        The query to execute on the data source.
+        rml:query is unofficially supported by RML, but not in the 
+        specification.
+        """ ;
+        sh:message """
+        rml:query is required for relational database. 
+        Must be provided once as a string.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:tableName
+    sh:property [
+        sh:path rr:tableName ;
+        sh:name "rr:tableName" ;
+        sh:description """
+        The value of rr:tableName specifies the table or view name of 
+        the base table or view. Its value MUST be a valid 
+        schema-qualified name that names an existing base table or 
+        view in the input database.
+        """ ;
+        sh:message """
+        rr:tableName must be a string Literal and may only be provided 
+        once.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rml:referenceFormulation
+    sh:property [
+        sh:path rml:referenceFormulation ;
+        sh:name "rml:referenceFormulation" ;
+        sh:description """
+        The reference formulation (rml:referenceFormulation) defines the 
+        reference formulation used to refer to the elements of the data source.
+        The reference formulation must be specified in the case of databases 
+        and XML and JSON data sources. By default SQL2008 for databases, as 
+        SQL2008 is the default for R2RML, XPath for XML and JSONPath for JSON 
+        data sources. 
+        """ ;
+        sh:message """
+        Reference formulation for CSV files must be ql:CSV.
+        TSV files must use ql:TSV. Providing rml:referenceFormulation for 
+        tabular data is optional.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:in (ql:CSV ql:TSV) ;
+    ] ;
+.
+
+# RML Logical Source: DCAT Dataset
+schema:DCATDatasetShape
+    a sh:NodeShape ;
+    sh:targetClass dcat:Dataset ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'dcat:Dataset'
+    sh:name "RML Logical Source description: DCAT Dataset" ;
+    sh:description """
+    An RML Logical Source description for a DCAT Dataset describes how a DCAT
+    Dataset must be accessed.
+    """ ;
+    sh:message """
+    An RML Logical Source description for a DCAT Dataset requires exactly one
+    dcat:distribution property.
+    """ ;
+
+    # dcat:distribution
+    sh:property [
+        sh:path dcat:distribution ;
+        sh:name "dcat:distribution" ;
+        sh:description """
+        An available distribution of the dataset.
+        """ ;
+        sh:message """
+        Exactly one dcat:distribution is required to access a distribution of 
+        the data.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:class dcat:Distribution ;  # Must be a dcat:Distribution
+        sh:node schema:DCATDistributionShape ;  # dcat/distribution.ttl
+    ];
+.
+
+# DCAT Dataset: DCAT Distribution
+schema:DCATDistributionShape
+    a sh:NodeShape ;
+    sh:targetClass dcat:Distribution ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'dcat:Distribution'
+    sh:name "DCAT Dataset description: DCAT Distribution" ;
+    sh:description """
+    A DCAT Distribution is a specific representation of a dataset. A dataset 
+    might be available in multiple serializations that may differ in various 
+    ways, including natural language, media-type or format, schematic 
+    organization, temporal and spatial resolution, level of detail or profiles 
+    (which might specify any or all of the above). 
+    """ ;
+    sh:message """
+    A DCAT Distribution requires exactly one dcat:downloadURL property.
+    """ ;
+
+    # dcat:downloadURL
+    sh:property [
+        sh:path dcat:downloadURL ;
+        sh:name "dcat:downloadURL" ;
+        sh:description """
+        The URL of the downloadable file in a given format. E.g. CSV file or 
+        RDF file. The format is indicated by the distribution's dct:format 
+        and/or dcat:mediaType.
+        """ ;
+        sh:message """
+        Exactly one dcat:downloadURL is required to download the dataset.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+.
+

--- a/Shapes/shapes/v1/rr/graph_map.ttl
+++ b/Shapes/shapes/v1/rr/graph_map.ttl
@@ -1,0 +1,131 @@
+###############################################################################
+# R2RML Graph Map and graph shortcut shape                                    #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRGraphMapShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rr:graphMap" ;
+    sh:description """
+    Represents a graph map.
+    """ ;
+    sh:message """
+    rr:GraphMap must specify an rr:template, rml:reference, rr:column or
+    rr:constant with the IRI of the Named Graph.
+    """ ;
+
+    # Exactly one rr:template, one rml:reference, one rr:constant or one rr:column is required
+    sh:property [
+        sh:path [sh:alternativePath (rr:template rr:constant rml:reference rr:column)] ;
+        sh:name "rr:template/rr:constant/rml:reference/rr:column" ;
+        sh:description """
+        Exactly one rr:template, one rml:reference, one rr:constant or one rr:column is required.
+        """ ;
+        sh:message """
+        Exactly one rr:template, one rml:reference, one rr:constant or one rr:column is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:template
+    sh:property [
+        sh:path rr:template ;
+        sh:name "rr:template" ;
+        sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+        sh:message """
+        rr:template must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:constant
+    sh:property [
+        sh:path rr:constant ;
+        sh:name "rr:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+        sh:message """
+        rr:constant must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:reference
+    sh:property [
+        sh:path rml:reference ;
+        sh:name "rml:reference" ;
+        sh:description """
+        A property for indicating whether a term map is an RML reference.
+        """ ;
+        sh:message """
+        rml:reference must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:column
+    sh:property [
+        sh:path rr:column ;
+        sh:name "rr:column" ;
+        sh:description """
+        A property for indicating whether a term map is an R2RML column.
+        """ ;
+        sh:message """
+        rr:column must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:termType
+    sh:property [
+        sh:path rr:termType ;
+        sh:name "rr:termType" ;
+        sh:description """
+        An IRI indicating whether graph generated using the value 
+        from column name specified for rr:column or an RML reference
+        should be an IRI reference or blank node.
+        """ ;
+        sh:message """
+        rr:termType must be either rr:IRI or rr:BlankNode for an rr:GraphMap.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:in (rr:IRI rr:BlankNode) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+
+schema:RRgraphShape 
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rr:graph" ;
+    sh:description """
+    An IRI reference for use as the graph name of all triples generated with 
+    the GraphMap. 
+    """ ;
+    sh:message """
+    rr:graph must be an IRI.
+    """ ;
+    sh:nodeKind sh:IRI ;
+.

--- a/Shapes/shapes/v1/rr/logical_table.ttl
+++ b/Shapes/shapes/v1/rr/logical_table.ttl
@@ -1,0 +1,81 @@
+###############################################################################
+# R2RML Logical Table shape                                                   #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRLogicalTable
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rr:LogicalTable" ;
+    sh:description """
+    Represents a logical table.
+    """ ;
+    sh:message """
+    rr:LogicalTable must provide either one rr:tableName or one rr:sqlQuery.
+    rr:sqlVersion is optional. 
+    """ ;
+
+    # Exactly one rr:tableName or one rr:sqlQuery is required
+    sh:property [
+        sh:path [sh:alternativePath (rr:tableName rr:sqlQuery)] ;
+        sh:name "rr:tableName/rr:sqlQuery" ;
+        sh:description """
+        Exactly one rr:tableName or one rr:sqlQuery is required.
+        """ ;
+        sh:message """
+        Exactly one rr:tableName or one rr:sqlQuery is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:tableName
+    sh:property [
+        sh:path rr:tableName ;
+        sh:name "rr:tableName" ;
+        sh:description """
+        Schema-qualified name of a table or view.
+        """ ;
+        sh:message """
+        rr:tableName must be a string and may only be provided once.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:sqlQuery
+    sh:property [
+        sh:path rr:sqlQuery ;
+        sh:name "rr:sqlQuery" ;
+        sh:description """
+        A valid SQL query.
+        """ ;
+        sh:message """
+        rr:sqlQuery must be a string and may only be provided once.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:sqlVersion
+    sh:property [
+        sh:path rr:sqlVersion ;
+        sh:name "rr:sqlVersion" ;
+        sh:description """
+        An identifier for a SQL version.
+        """ ;
+        sh:message """
+        rr:sqlVersion may only be provided once and must its value must be 
+        rr:SQL2008.
+        """ ;
+        sh:nodeKind sh:IRI ;
+        sh:in (rr:SQL2008) ;
+    ] ;
+.

--- a/Shapes/shapes/v1/rr/object_map.ttl
+++ b/Shapes/shapes/v1/rr/object_map.ttl
@@ -1,0 +1,180 @@
+###############################################################################
+# R2RML Object Map and object shortcut shape                                  #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRObjectMapShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'rr:objectMap'
+    sh:name "rr:ObjectMap" ;
+    sh:description """
+    Represents an object map.
+    """ ;
+
+    # Exactly one rr:template, one rr:column, one rr:constant or one 
+    # rml:reference is required.
+    sh:property [
+        sh:path [sh:alternativePath (rr:template 
+                                     rr:column
+                                     rr:constant
+                                     rml:reference)] ;
+        sh:name "rr:template/rr:column/rr:constant/rml:reference" ;
+        sh:description """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+        sh:message """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:template
+    sh:property [
+        sh:path rr:template ;
+        sh:name "rr:template" ;
+        sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+        sh:message """
+        rr:template must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:column
+    sh:property [
+        sh:path rr:column ;
+        sh:name "rr:column" ;
+        sh:description """
+        Name of a column in the logical table. When generating RDF triples from
+        a logical table row, value from the specified column is used as the 
+        subject, predicate, or object (based upon the specific domain).
+        """ ;
+        sh:message """
+        rr:column must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:constant
+    sh:property [
+        sh:path rr:constant ;
+        sh:name "rr:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+    ] ;
+
+    # rml:reference
+    sh:property [
+        sh:path rml:reference ;
+        sh:name "rml:reference" ;
+        sh:description """
+        A reference rml:reference is used to refer to a column in case of 
+        databases, a record in case of CSV or TSV data source, an element in 
+        case of XML data source, an object in case of a JSON data source, etc.
+
+        A reference must be a valid identifier, considering the reference 
+        formulation (rml:referenceFormulation) specified. The reference can be
+        an absolute path, or a path relative to the iterator specified at the 
+        logical source. 
+        """ ;
+        sh:message """
+        rml:reference must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:termType
+    sh:property [
+        sh:path rr:termType ;
+        sh:name "rr:termType" ;
+        sh:description """
+        An IRI indicating whether subject or object generated using the 
+        value from column name specified for rr:column should be an IRI 
+        reference, blank node, or a literal. 
+        """ ;
+        sh:message """
+        rr:termType must be either rr:IRI, rr:BlankNode or rr:Literal for
+        a rr:ObjectMap.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:in (rr:IRI rr:BlankNode rr:Literal) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rr:language and rr:datatype may not be provided at the same time
+    sh:property [
+        sh:path [ sh:alternativePath (rr:language rr:datatype) ] ;
+        sh:name "rr:language/rr:datatype" ;
+        sh:description """
+        rr:language and rr:datatype may not be provided at the same time.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+    ];
+
+    # rr:language
+    sh:property [
+        sh:path rr:language ;
+        sh:name "rr:language" ;
+        sh:description """
+        Specified the language for the object component for the generated 
+        triple from a logical table row or iterator.
+        """ ;
+        sh:message """
+        rr:language must be a valid language tag according to BCP47 and may 
+        only be provided once as string.
+        """ ;
+    sh:pattern "^((?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?:([A-Za-z]{2,3}(-(?:[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4})(-(?:[A-Za-z]{4}))?(-(?:[A-Za-z]{2}|[0-9]{3}))?(-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?:[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?:x(-[A-Za-z0-9]{1,8})+))?)|(?:x(-[A-Za-z0-9]{1,8})+))$";
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:datatype xsd:string ;
+    ];
+
+    # rr:datatype
+    sh:property [
+        sh:path rr:datatype ;
+        sh:name "rr:datatype" ;
+        sh:description """
+        Specifies the datatype of the object component for the generated triple
+        from a logical table row or iterator.
+        """ ;
+        sh:message """
+        rr:datatype may only be provided once as an IRI.
+        """ ;
+        sh:maxCount 1 ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+
+schema:RRobjectShape 
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'rr:object'
+    sh:name "rr:object" ;
+    sh:description """
+    An IRI reference for use as object for all the RDF triples generated from 
+    a logical table row or iterator.
+    """ ;
+.

--- a/Shapes/shapes/v1/rr/predicate_map.ttl
+++ b/Shapes/shapes/v1/rr/predicate_map.ttl
@@ -1,0 +1,141 @@
+###############################################################################
+# R2RML Predicate Map and predicate shortcut shape                            #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRPredicateMapShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rr:PredicateMap" ;
+    sh:description """
+    Represents a predicate map.
+    """ ;
+    # Exactly one rr:template, one rr:column, one rr:constant or one 
+    # rml:reference is required.
+    sh:property [
+        sh:path [sh:alternativePath (rr:template 
+                                     rr:column
+                                     rr:constant
+                                     rml:reference)] ;
+        sh:name "rr:template/rr:column/rr:constant/rml:reference" ;
+        sh:description """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+        sh:message """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:template
+    sh:property [
+        sh:path rr:template ;
+        sh:name "rr:template" ;
+        sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+        sh:message """
+        rr:template must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:column
+    sh:property [
+        sh:path rr:column ;
+        sh:name "rr:column" ;
+        sh:description """
+        Name of a column in the logical table. When generating RDF triples from
+        a logical table row, value from the specified column is used as the 
+        subject, predicate, or object (based upon the specific domain).
+        """ ;
+        sh:message """
+        rr:column must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:constant
+    sh:property [
+        sh:path rr:constant ;
+        sh:name "rr:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+        sh:message """
+        rr:constant must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:reference
+    sh:property [
+        sh:path rml:reference ;
+        sh:name "rml:reference" ;
+        sh:description """
+        A reference rml:reference is used to refer to a column in case of 
+        databases, a record in case of CSV or TSV data source, an element in 
+        case of XML data source, an object in case of a JSON data source, etc.
+
+        A reference must be a valid identifier, considering the reference 
+        formulation (rml:referenceFormulation) specified. The reference can be
+        an absolute path, or a path relative to the iterator specified at the 
+        logical source. 
+        """ ;
+        sh:message """
+        rml:reference must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:termType
+    sh:property [
+        sh:path rr:termType ;
+        sh:name "rr:termType" ;
+        sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified for rr:column should be an IRI reference, 
+        blank node, or a literal.
+        """ ;
+        sh:message """
+        rr:termType must be either rr:IRI for an rr:PredicateMap.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:in (rr:IRI) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+
+schema:RRpredicateShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rr:predicate" ;
+    sh:description """
+    Specifies the predicate for the generated triple from the logical table 
+    row or iterator.
+    """ ;
+    sh:message """
+    rr:predicate must be an IRI.
+    """ ;
+    sh:nodeKind sh:IRI ;
+.

--- a/Shapes/shapes/v1/rr/predicate_object_map.ttl
+++ b/Shapes/shapes/v1/rr/predicate_object_map.ttl
@@ -1,0 +1,154 @@
+###############################################################################
+# R2RML Predicate Object Map shape                                            #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRPredicateObjectMapShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    
+    # Either an rr:predicate or rr:predicateMap must be provided, not both
+    sh:property [
+        sh:path [sh:alternativePath (rr:predicate rr:predicateMap)] ;
+        sh:name "rr:predicate/rr:predicateMap" ;
+        sh:description """
+        Either an rr:predicate or rr:predicateMap must be provided, not both.
+        """ ;
+        sh:message """
+        Either an rr:predicate or rr:predicateMap must be provided, not both.
+        """ ;
+        sh:minCount 1 ;
+    ] ;
+
+    # rr:predicateMap
+    sh:property [
+        sh:path rr:predicateMap ;
+        sh:name "rr:predicateMap" ;
+        sh:description """
+        A PredicateMap element to generate the predicate component of the 
+        (predicate, object) pair from a logical table row or iterator.
+        """ ;
+        sh:message """
+        rr:predicateMap must be an IRI or blank node and be provided once.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RRPredicateMapShape ;
+    ] ;
+
+    # rr:predicate
+    sh:property [
+        sh:path rr:predicate ;
+        sh:name "rr:predicate" ;
+        sh:description """
+        Specifies the predicate for the generated triple from the logical table 
+        row or iterator.
+        """ ;
+        sh:message """
+        rr:predicate must be an IRI and be provided once.
+        """ ;
+        sh:nodeKind sh:IRI ;
+        sh:node schema:RRpredicateShape ;
+    ] ;
+
+    # Either an rr:object or rr:objectMap must be provided, not both
+    sh:property [
+        sh:path [sh:alternativePath (rr:object rr:objectMap)] ;
+        sh:name "rr:object/rr:objectMap" ;
+        sh:description """
+        Either an rr:object or rr:objectMap must be provided, not both.
+        """ ;
+        sh:message """
+        Either an rr:object or rr:objectMap must be provided, not both.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:objectMap
+    sh:property [
+        sh:path rr:objectMap ;
+        sh:name "rr:objectMap" ;
+        sh:description """
+        An ObjectMap element to generate the object component of the 
+        (predicate, object) pair from a logical table row or iterator.
+        """ ;
+        sh:message """
+        rr:objectMap must be an IRI or blank node and be provided once.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:xone ([sh:node schema:RRObjectMapShape] 
+                 [sh:node schema:RRRefObjectMapShape]) ;
+    ] ;
+
+    # rr:object
+    sh:property [
+        sh:path rr:object ;
+        sh:name "rr:object" ;
+        sh:description """
+        Specifies the object for the generated triple from the logical table 
+        row or iterator.
+        """ ;
+        sh:message """
+        rr:object must be an IRI and be provided once.
+        """ ;
+        sh:nodeKind sh:IRI ;
+        sh:node schema:RRobjectShape ;
+    ] ;
+
+    # Either an rr:graph or rr:graphMap may be optionally be provided, but not 
+    # both
+    sh:property [
+        sh:path [sh:alternativePath (rr:graph rr:graphMap)] ;
+        sh:name "rr:graph/rr:graphMap" ;
+        sh:description """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but 
+        not both.
+        """ ;
+        sh:message """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but
+        not both.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:graphMap
+    sh:property [
+        sh:path rr:graphMap ;
+        sh:name "rr:graphMap" ;
+        sh:description """
+        Specifies a GraphMap. When used with a SubjectMap element, all the RDF 
+        triples generated from a logical row will be stored in the specified 
+        named graph. Otherwise, the RDF triple generated using the 
+        (predicate, object) pair will be stored in the specified named graph.
+        """ ;
+        sh:message """
+        rr:graphMap must be either an IRI or blank node. 
+        """ ;
+        sh:node schema:RRGraphMapShape ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+    ] ;
+
+    # rr:graph
+    sh:property [
+        sh:path rr:graph ;
+        sh:name "rr:graph" ;
+        sh:description """
+        An IRI reference for use as the graph name of all triples generated 
+        with the GraphMap.
+        """ ;
+        sh:message """
+        rr:graphMap must be an IRI. 
+        """ ;
+        sh:node schema:RRgraphShape ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.

--- a/Shapes/shapes/v1/rr/ref_object_map.ttl
+++ b/Shapes/shapes/v1/rr/ref_object_map.ttl
@@ -1,0 +1,88 @@
+###############################################################################
+# R2RML RefObjectMap shape                                                    #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRRefObjectMapShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rr:RefObjectMap" ;
+    sh:description """
+    Represents a reference object map.
+    """ ;
+    sh:message """
+    rr:RefObjectMap must specify a rr:parentTriplesMap and zero or more 
+    rr:joinConditions.
+    """ ;
+
+    # rr:parentTriplesMap
+    sh:property [
+        sh:path rr:parentTriplesMap ;
+        sh:name "rr:parentTriplesMap" ;
+        sh:description """
+        Specifies the TriplesMap element corresponding to the parent logical 
+        table of the foreign key constraint.
+        """ ;
+        sh:message """
+        rr:parentTriplesMap may only be provided once and must be an IRI or 
+        blank node referring to a rr:TriplesMap.
+        """ ;
+        sh:class rr:TriplesMap ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    sh:property [
+        sh:closed "true"^^xsd:boolean ;
+        sh:path rr:joinCondition ;
+        sh:name "rr:joinCondition" ;
+        sh:description """
+        Specifies the join condition for joining the child logical table with 
+        the parent logical table of the foreign key constraint.
+        """ ;
+        sh:message """
+        rr:joinCondition must specify an rr:parent and rr:child.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+
+        # rr:parent
+        sh:property [
+            sh:path rr:parent ;
+            sh:name "rr:parent" ;
+            sh:description """
+            Names a column in the parent table of a join.
+            """ ;
+            sh:message """
+            rr:parent must be string and only occur once.
+            """ ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+        ] ;
+
+        # rr:child
+        sh:property [
+            sh:path rr:child ;
+            sh:name "rr:child" ;
+            sh:description """
+            Names a column in the child table of a join.
+            """ ;
+            sh:message """
+            rr:child must be string and only occur once.
+            """ ;
+            sh:minCount 1 ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:datatype xsd:string ;
+        ] ;
+    ] ;
+.

--- a/Shapes/shapes/v1/rr/subject_map.ttl
+++ b/Shapes/shapes/v1/rr/subject_map.ttl
@@ -1,0 +1,209 @@
+###############################################################################
+# R2RML Subject Map and subject shortcut shape                                #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RRSubjectMapShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'rr:subjectMap'
+    sh:name "rr:SubjectMap" ;
+    sh:description """
+    Represents a subject map.
+    """ ;
+    sh:message """
+    rr:subjectMap requires one rr:template or one rr:column or 1 rr:constant or
+    one rml:reference.
+    """ ;
+
+    # Exactly one rr:template, one rr:column, one rr:constant or one 
+    # rml:reference is required.
+    sh:property [
+        sh:path [sh:alternativePath (rr:template 
+                                     rr:column
+                                     rr:constant
+                                     rml:reference)] ;
+        sh:name "rr:template/rr:column/rr:constant/rml:reference" ;
+        sh:description """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+        sh:message """
+        Exactly one rr:template, one rr:column, one rr:constant or one 
+        rml:reference is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:template
+    sh:property [
+        sh:path rr:template ;
+        sh:name "rr:template" ;
+        sh:description """
+        A template (format string) to specify how to generate a value for a 
+        subject, predicate, or object, using one or more columns from a logical
+        table row or iterator.
+        """ ;
+        sh:message """
+        rr:template must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:column
+    sh:property [
+        sh:path rr:column ;
+        sh:name "rr:column" ;
+        sh:description """
+        Name of a column in the logical table. When generating RDF triples from
+        a logical table row, value from the specified column is used as the 
+        subject, predicate, or object (based upon the specific domain).
+        """ ;
+        sh:message """
+        rr:column must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:constant
+    sh:property [
+        sh:path rr:constant ;
+        sh:name "rr:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+        sh:message """
+        rr:constant must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:reference
+    sh:property [
+        sh:path rml:reference ;
+        sh:name "rml:reference" ;
+        sh:description """
+        A reference rml:reference is used to refer to a column in case of 
+        databases, a record in case of CSV or TSV data source, an element in 
+        case of XML data source, an object in case of a JSON data source, etc.
+
+        A reference must be a valid identifier, considering the reference 
+        formulation (rml:referenceFormulation) specified. The reference can be
+        an absolute path, or a path relative to the iterator specified at the 
+        logical source. 
+        """ ;
+        sh:message """
+        rml:reference must be a string.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+    ] ;
+
+    # rr:class
+    sh:property [
+        sh:path rr:class ;
+        sh:name "rr:class" ;
+        sh:description """
+        The subject value generated for a logical table row will be asserted 
+        as an instance of this RDFS class.
+        """ ;
+        sh:message """
+        rr:class must be an IRI and may be specified multiple times.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rr:termType
+    sh:property [
+        sh:path rr:termType ;
+        sh:name "rr:termType" ;
+        sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified for rr:column should be an IRI reference, 
+        or blank node.
+        """ ;
+        sh:message """
+        rr:termType must be either rr:IRI or rr:BlankNode for an rr:SubjectMap.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:in (rr:IRI rr:BlankNode) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # Either an rr:graph or rr:graphMap may be optionally be provided, but not 
+    # both
+    sh:property [
+        sh:path [sh:alternativePath (rr:graph rr:graphMap)] ;
+        sh:name "rr:graph/rr:graphMap" ;
+        sh:description """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but 
+        not both.
+        """ ;
+        sh:message """
+        Either an rr:graph or rr:graphMap may be optionally be provided, but
+        not both.
+        """ ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:graphMap
+    sh:property [
+        sh:path rr:graphMap ;
+        sh:name "rr:graphMap" ;
+        sh:description """
+        Specifies a GraphMap. When used with a SubjectMap element, all the RDF 
+        triples generated from a logical row will be stored in the specified 
+        named graph. Otherwise, the RDF triple generated using the 
+        (predicate, object) pair will be stored in the specified named graph.
+        """ ;
+        sh:message """
+        rr:graphMap must be either an IRI or blank node. 
+        """ ;
+        sh:node schema:RRGraphMapShape ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+    ] ;
+
+    # rr:graph
+    sh:property [
+        sh:path rr:graph ;
+        sh:name "rr:graph" ;
+        sh:description """
+        An IRI reference for use as the graph name of all triples generated 
+        with the GraphMap.
+        """ ;
+        sh:message """
+        rr:graphMap must be an IRI. 
+        """ ;
+        sh:node schema:RRgraphShape ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.
+
+
+schema:RRsubjectShape
+    a sh:NodeShape ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'rr:subject'
+    sh:name "rr:subject" ;
+    sh:description """
+    An IRI reference for use as subject for all the RDF triples generated from 
+    a logical table row or iterator.
+    """ ;
+    sh:message """
+    rr:subject shortcut for rr:subjectMap must be an IRI or BlankNode.
+    """ ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+.

--- a/Shapes/shapes/v1/rr/triples_map.ttl
+++ b/Shapes/shapes/v1/rr/triples_map.ttl
@@ -1,0 +1,134 @@
+###############################################################################
+# R2RML Triples Map shape                                                     #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# Validate an RML Triples Map
+schema:RRTriplesMapShape
+    a sh:NodeShape ;
+    sh:targetClass rr:TriplesMap ;
+    sh:message "rr:TriplesMap" ;
+    sh:description """
+    Represents a triples map.
+    """ ;
+    sh:message """
+    rr:TriplesMap requires exactly one rr:subject or one rr:subjectMap and zero
+    or more rr:predicateObjectMaps.
+    """ ;
+    sh:closed "true"^^xsd:boolean ;
+    sh:ignoredProperties (rdf:type) ;
+
+    # A single rml:logicalSource or rr:logicalTable for a rr:triplesMap is 
+    # required.
+    sh:property [
+        sh:path [sh:alternativePath (rr:logicalTable rml:logicalSource)] ;
+        sh:name "rr:logicalTable/rml:logicalSource" ;
+        sh:description """
+        Either one rr:logicalTable or one rml:logicalSource is required, not 
+        both.
+        """ ;
+        sh:message """
+        Either one rr:logicalTable or one rml:logicalSource is required, not 
+        both.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:logicalTable
+    sh:property [
+        sh:path rr:logicalTable ;
+        sh:name "rr:logicalTable" ;
+        sh:description """
+        Definition of logical table to be mapped.
+        """ ;
+        sh:message """
+        Exactly one rr:logicalTable is required to access a relational 
+        database.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RRLogicalTableShape ;
+    ];
+
+    # rml:logicalSource
+    sh:property [
+        sh:path rml:logicalSource ;
+        sh:name "rml:logicalSource" ;
+        sh:description """
+        A logical source is any source that is mapped to RDF triples. A logical 
+        source is a Base Source, rml:BaseSource.
+        """ ;
+        sh:message """
+        Exactly one rml:logicalSource is required to access the data source.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RMLLogicalSourceShape ;
+    ] ;
+
+    # Either an rr:subject or rr:SubjectMap is required
+    sh:property [
+        sh:path [sh:alternativePath (rr:subjectMap rr:subject)] ;
+        sh:name "rr:subjectMap/rr:subject" ;
+        sh:description """
+        Either one rr:subject or one rr:SubjectMap is required, not both.
+        """ ;
+        sh:message """
+        Either one rr:subject or one rr:SubjectMap is required, not both.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rr:subjectMap
+    sh:property [
+        sh:path rr:subjectMap ;
+        sh:name "rr:subjectMap" ;
+        sh:description """
+        A SubjectMap element to generate a subject from a logical table row or
+        iterator.
+        """ ;
+        sh:message """
+        rr:SubjectMap must be an IRI or blank node.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RRSubjectMapShape ;
+    ] ;
+
+    # rr:subject
+    sh:property [
+        sh:path rr:subject ;
+        sh:name "rr:subject" ;
+        sh:description """
+        An IRI reference for use as subject for all the RDF triples generated 
+        from a logical table row or iterator.
+        """ ;
+        sh:message """
+        rr:subject must be an IRI or blank node.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RRsubjectShape ;
+    ] ;
+
+    # rr:predicateObjectMap
+    sh:property [
+        sh:path rr:predicateObjectMap ;
+        sh:name "rr:predicateObjectMap" ;
+        sh:description """
+        A PredicateObjectMap element to generate (predicate, object) pair from 
+        a logical table row.
+        """ ;
+        sh:message """
+        rr:PredicateObjectMap must be an IRI or blank node.
+        """ ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RRPredicateObjectMapShape ; 
+    ] ;
+.

--- a/Shapes/shapes/v1/sd/service.ttl
+++ b/Shapes/shapes/v1/sd/service.ttl
@@ -1,0 +1,88 @@
+###############################################################################
+# RML Logical Source: SD Service shape                                        #
+# Author: Dylan Van Assche                                                    #
+# Copyright IDLab - UGent - IMEC (2020)                                       #
+###############################################################################
+@prefix format: <http://www.w3.org/ns/formats/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+# RML Logical Source: SD Service
+schema:SDServiceShape
+    a sh:NodeShape ;
+    sh:targetClass sd:Service ;
+    sh:closed "true"^^xsd:boolean ;  # Enforce CWA
+    sh:ignoredProperties (rdf:type) ;  # Already targets 'sd:Service'
+    sh:name "RML Logical Source description: SD Service" ;
+    sh:description """
+    An RML Logical Source description for an SD Service describes how a 
+    SPARQL service must be accessed. 
+    """ ;
+    sh:message """ 
+    An RML Logical Source description for an SD Service requires exactly
+    one sd:endpoint, one sd:supportedLanguage and one sd:resultFormat 
+    properties.
+    """ ;
+
+    # sd:endpoint: SPARQL service endpoint IRI
+    sh:property [
+        sh:path sd:endpoint ;
+        sh:name "sd:endpoint" ;
+        sh:description """
+        Relates an instance of sd:Service to a SPARQL endpoint that implements 
+        the SPARQL Protocol service (SPROT) for the service. The object of the 
+        sd:endpoint property is an IRI.
+        """ ;
+        sh:message """
+        Exactly one endpoint IRI is required to access a SPARQL service.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # sd:supportedLanguage: supported SPARQL language versions
+    sh:property [
+        sh:path sd:supportedLanguage ;
+        sh:name "sd:supportedLanguage" ;
+        sh:description """
+        Relates an instance of sd:Service to a SPARQL language 
+        (e.g. Query and Update) that it implements.
+        """ ;
+        sh:message """
+        The supported language for a RML Logical Source: SD Service doesn't 
+        match with sd:SPARQL10Query or sd:SPARQL11Query.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:in (sd:SPARQL10Query sd:SPARQL11Query) ;
+    ] ;
+
+    # sd:resultFormat: formats in which the results are returned
+    sh:property [
+        sh:path sd:resultFormat ;
+        sh:name "sd:resultFormat" ;
+        sh:description """
+        Relates an instance of sd:Service to a format that is supported for 
+        serializing query results.
+        """ ;
+        sh:message """
+        The result format for a RML Logical Source: SD Service doesn't match 
+        with  format:SPARQL_Results_XML, format:SPARQL_Results_JSON, 
+        format:SPARQL_Results_CSV or format:SPARQL_Results_TSV.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:in (
+            format:SPARQL_Results_XML
+            format:SPARQL_Results_JSON
+            format:SPARQL_Results_CSV
+            format:SPARQL_Results_TSV
+        ) ;
+    ] ;
+.

--- a/Shapes/tests.py
+++ b/Shapes/tests.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+#
+# (c) Dylan Van Assche (2020-2021)
+# IDLab - Ghent University - imec
+# MIT license
+#
+
+import argparse
+import unittest
+import logging
+from parameterized import parameterized
+from glob import glob
+from os.path import abspath
+from typing import Tuple, List
+from rdflib import Graph
+
+from mapping_validator import MappingValidator
+
+VALIDATION_MAPPING_RULES_DIR = abspath('tests/assets/validation') + '/*/*.ttl'
+RML_RULES_SHAPE = abspath('rml_v1_shape.ttl')
+
+
+class MappingValidatorTests(unittest.TestCase):
+    def _validate_rules(self, path: str) -> None:
+        rules = Graph().parse(path, format='turtle')
+        mapping_validator = MappingValidator(RML_RULES_SHAPE)
+        mapping_validator.validate(rules)
+
+    def test_non_existing_mapping_rules(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            p = abspath('tests/assets/io/mapping_files/mapping_does_not_exist.ttl')
+            self._validate_rules(p)
+
+    @parameterized.expand([(p,) for p in sorted(glob(VALIDATION_MAPPING_RULES_DIR))])
+    def test_validation_rules(self, path: str) -> None:
+        """
+        Test if our SHACL shapes are able to validate our validation mapping
+        rules test cases.
+        """
+        print(f'Testing validation with: {path}')
+        # All test cases with 'success' in their path should succeed.
+        if 'validation_duplicate_columns.ttl' in path:
+            self.skipTest('Duplicate CSVW column checks are not added yet')
+
+        if 'success' in path:
+            self._validate_rules(path)
+        # The other test cases shouldn't validate
+        else:
+            with self.assertRaises(ValueError):
+                self._validate_rules(path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Execute tests for SHACL shapes on RML mapping rules.')
+    parser.add_argument('--verbose', '-v', action='count', default=1,
+                        help='Set verbosity level of messages. Example: -vvv')
+    args = parser.parse_args()
+
+    args.verbose = 70 - (10 * args.verbose) if args.verbose > 0 else 0
+    logging.basicConfig(level=args.verbose,
+                        format='%(asctime)s %(levelname)s: %(message)s',
+                        datefmt='%Y-%m-%d %H:%M:%S')
+
+    unittest.main(failfast=True)

--- a/Shapes/tests/assets/mapping_files/validator_rules_invalid.rml.ttl
+++ b/Shapes/tests/assets/mapping_files/validator_rules_invalid.rml.ttl
@@ -1,0 +1,137 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<TriplesMap1> a rr:TriplesMap;
+    
+  rml:logicalSource [ 
+    rml:source "student.json";
+    rml:referenceFormulation ql:JSONPath;
+  ];
+
+  rr:subjectMap [ 
+    rr:template "http://example.com/{ID}/{Name}";
+    rr:class foaf:Person 
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ; 
+    rr:objectMap [ rml:reference "ID" ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ; 
+    rr:objectMap [ rml:reference "Name" ]
+  ].
+  
+<TriplesMap2>
+  a rr:TriplesMap;
+
+  rml:logicalSource [
+     rml:source <#DB_source>;
+     rr:tableName "Employee"
+  ];
+
+  rr:subjectMap [ rml:reference "firstname" ];
+
+  rr:predicateObjectMap [
+    rr:predicate foaf:name;
+    rr:objectMap [
+      rml:reference "firstname"
+    ]
+  ] .
+
+<#DB_source> a d2rq:Database;
+  d2rq:jdbcDSN "CONNECTIONDSN";
+  d2rq:username "postgres";
+  d2rq:password "" .
+  
+<TriplesMap3>
+  a rr:TriplesMap;
+
+    rml:logicalSource [
+    rml:referenceFormulation ql:JSONPath;
+    rml:iterator "/";
+    rml:query " select distinct ?resource ?resource_label where { ?resource rdfs:label ?resource_label } " ] ;
+
+  rr:subjectMap [ rml:reference "firstname" ];
+
+  rr:predicateObjectMap [
+    rr:predicate foaf:name;
+    rr:objectMap [
+      rml:reference "firstname"
+    ]
+  ] .
+
+ <#SPARQL_JSON_source> a sd:Service ;
+    sd:endpoint  <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat  <http://www.w3.org/ns/formats/SPARQL_Results_JSON> .
+
+<TriplesMap4>
+  a rr:TriplesMap;
+
+    rml:logicalSource [
+     rml:source <#DCAT_source> ;
+    rml:referenceFormulation ql:XPath;
+    rml:iterator "/" ];
+
+  rr:subjectMap [ rml:reference "firstname" ];
+
+  rr:predicateObjectMap [
+    rr:predicate foaf:name;
+    rr:objectMap [
+      rml:reference "firstname"
+    ]
+  ] .
+
+<#DCAT_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://example.org/file.xml" ].
+
+<#TriplesMap5> 
+a rr:TriplesMap;
+rml:logicalSource [
+    rml:source <#API_template_source> ;
+    rml:referenceFormulation ql:JSONPath;
+    rml:iterator "$" ] ;
+rr:subjectMap [ rml:reference "firstname" ].
+
+<#API_template_source>
+    a hydra:IriTemplate ;
+    hydra:template "https://biblio.ugent.be/publication/{id}?format={format}";
+    hydra:mapping
+        [ a hydra:TemplateMapping ;
+          hydra:variable "id";
+          hydra:required true ],
+        [ a hydra:TemplateMapping ;
+          hydra:variable "format";
+          hydra:required false ] .
+
+
+<#TriplesMap6> 
+a rr:TriplesMap;
+rml:logicalSource [
+    rml:source <#CSVW_source> ;
+    rml:referenceFormulation ql:CSV ] ;
+rr:subjectMap [ rml:reference "firstname" ].
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "http://rml.io/data/csvw/Airport.csv" ;
+    csvw:dialect [ a csvw:Dialect;
+        csvw:delimiter ";";
+        csvw:encoding "UTF-8";
+        csvw:header "1"^^xsd:boolean
+    ] .
+        

--- a/Shapes/tests/assets/mapping_files/validator_rules_valid.rml.ttl
+++ b/Shapes/tests/assets/mapping_files/validator_rules_valid.rml.ttl
@@ -1,0 +1,132 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<TriplesMap1> a rr:TriplesMap;
+    
+  rml:logicalSource [ 
+    rml:source "student.json";
+    rml:referenceFormulation ql:JSONPath;
+    rml:iterator "$.students[*]"
+  ];
+
+  rr:subjectMap [ 
+    rr:template "http://example.com/{ID}/{Name}";
+    rr:class foaf:Person 
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ; 
+    rr:objectMap [ rml:reference "ID" ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ; 
+    rr:objectMap [ rml:reference "Name" ]
+  ].
+  
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+  
+<TriplesMap3>
+  a rr:TriplesMap;
+    rml:logicalSource [
+     rml:source <#SPARQL_JSON_source> ;
+    rml:referenceFormulation ql:JSONPath;
+    rml:iterator "/";
+    rml:query " select distinct ?resource ?resource_label where { ?resource rdfs:label ?resource_label } " ] ;
+
+  rr:subjectMap [ rml:reference "firstname" ];
+
+  rr:predicateObjectMap [
+    rr:predicate foaf:name;
+    rr:objectMap [
+      rml:reference "firstname"
+    ]
+  ] .
+
+ <#SPARQL_JSON_source> a sd:Service ;
+    sd:endpoint  <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat  <http://www.w3.org/ns/formats/SPARQL_Results_JSON> .
+
+<TriplesMap4>
+  a rr:TriplesMap;
+
+    rml:logicalSource [
+     rml:source <#DCAT_source> ;
+    rml:referenceFormulation ql:XPath;
+    rml:iterator "/" ];
+
+  rr:subjectMap [ rml:reference "firstname" ];
+
+  rr:predicateObjectMap [
+    rr:predicate foaf:name;
+    rr:objectMap [
+      rml:reference "firstname"
+    ]
+  ] .
+
+<#DCAT_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://example.org/file.xml" ;
+        dcat:mediaType "text/xml"
+        ] .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "\t";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].
+

--- a/Shapes/tests/assets/validation/csvw/validation_columns_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_columns_success.ttl
@@ -1,0 +1,54 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_header_overide.csv" ;
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                # csvw:null is default '', check fallback here
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        )
+    ];
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "true"^^xsd:boolean;
+        csvw:headerRowCount "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_comment_prefix_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_comment_prefix_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/comment_prefix.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:commentPrefix "$";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_delimiter_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_delimiter_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "\t";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_double_quote_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_double_quote_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/double_quote.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:doubleQuote "true"^^xsd:boolean;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_columns.ttl
@@ -1,0 +1,54 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_header_overide.csv" ;
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "name";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                # csvw:null is default '', check fallback here
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        )
+    ];
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "true"^^xsd:boolean;
+        csvw:headerRowCount "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_comment_prefix.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_comment_prefix.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/comment_prefix.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:commentPrefix "$";
+        csvw:commentPrefix "%";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_delimiter.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_delimiter.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "\t";
+        csvw:delimiter "\n";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_double_quote.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_double_quote.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/double_quote.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:doubleQuote "true"^^xsd:boolean;
+        csvw:doubleQuote "false"^^xsd:boolean;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_encoding.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_encoding.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/encoding.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:encoding "utf-16";
+        csvw:encoding "utf-8";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_escape_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_escape_char.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/escape_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:escapeChar "%";  # CSVW doesn't provide this in the ontology!
+        csvw:escapeChar "^";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_header.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_header.ttl
@@ -1,0 +1,54 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_no_header.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "0"^^xsd:boolean;  # default true
+        csvw:header "1"^^xsd:boolean;
+    ];
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                csvw:null "";
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        );
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_line_terminators.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_line_terminators.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/line_terminators.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:lineTerminators "\r\n";
+        csvw:lineTerminators "\n";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_name_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_name_columns.ttl
@@ -1,0 +1,55 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_header_overide.csv" ;
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:name "id2";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                # csvw:null is default '', check fallback here
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        )
+    ];
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "true"^^xsd:boolean;
+        csvw:headerRowCount "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_null_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_null_columns.ttl
@@ -1,0 +1,55 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_header_overide.csv" ;
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                # csvw:null is default '', check fallback here
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+                csvw:null "1";
+            ]
+        )
+    ];
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "true"^^xsd:boolean;
+        csvw:headerRowCount "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_quote_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_quote_char.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/quote_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:quoteChar "^";
+        csvw:quoteChar "%";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_skip_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_skip_columns.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_columns.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipColumns "1"^^xsd:integer;
+        csvw:skipColumns "2"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{name}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:age ; 
+        rr:objectMap [ 
+            rml:reference "age" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_skip_initial_space.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_skip_initial_space.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_initial_space.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipInitialSpace "true"^^xsd:boolean;
+        csvw:skipInitialSpace "false"^^xsd:boolean;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_skip_rows.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_skip_rows.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_rows.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipRows "1"^^xsd:integer;
+        csvw:skipRows "2"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_duplicate_trim_mode.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_duplicate_trim_mode.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_start.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "start";
+        csvw:trim "end";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_empty_comment_prefix.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_empty_comment_prefix.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/comment_prefix.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:commentPrefix "";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_empty_delimiter.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_empty_delimiter.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_empty_escape_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_empty_escape_char.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/escape_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:escapeChar "";  # CSVW doesn't provide this in the ontology!
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_empty_line_terminators.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_empty_line_terminators.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/line_terminators.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:lineTerminators "";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_empty_quote_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_empty_quote_char.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/quote_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:quoteChar "";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_encoding_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_encoding_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/encoding.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:encoding "utf-16";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_escape_char_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_escape_char_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/escape_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:escapeChar "%";  # CSVW doesn't provide this in the ontology!
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_header_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_header_success.ttl
@@ -1,0 +1,53 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_no_header.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "0"^^xsd:boolean;  # default true
+    ];
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                csvw:null "";
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        );
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_comment_prefix.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_comment_prefix.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/comment_prefix.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:commentPrefix "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_datatype_trim_mode.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_datatype_trim_mode.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_start.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_delimiter.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_delimiter.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_double_quote.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_double_quote.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/double_quote.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:doubleQuote "1"^^xsd:integer;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_encoding.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_encoding.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/encoding.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:encoding "1"^^xsd:boolean;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_escape_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_escape_char.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/escape_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:escapeChar "1"^^xsd:boolean;  # CSVW doesn't provide this in the ontology!
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_header.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_header.ttl
@@ -1,0 +1,53 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_no_header.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "0"^^xsd:integer;  # default true
+    ];
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                csvw:null "";
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        );
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_line_terminators.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_line_terminators.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/line_terminators.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:lineTerminators "1"^^xsd:boolean;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_name_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_name_columns.ttl
@@ -1,0 +1,54 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_header_overide.csv" ;
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "true"^^xsd:boolean;
+                csvw:null "-1";
+            ]
+            [
+                csvw:name "name";
+                # csvw:null is default '', check fallback here
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        )
+    ];
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "true"^^xsd:boolean;
+        csvw:headerRowCount "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_null_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_null_columns.ttl
@@ -1,0 +1,54 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/has_header_overide.csv" ;
+    csvw:tableSchema [
+        a csvw:TableSchema;
+        csvw:columns (
+            [
+                csvw:name "id";
+                csvw:null "1"^^xsd:integer;
+            ]
+            [
+                csvw:name "name";
+                # csvw:null is default '', check fallback here
+            ]
+            [
+                csvw:name "age";
+                csvw:null "0";
+            ]
+        )
+    ];
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:header "true"^^xsd:boolean;
+        csvw:headerRowCount "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_quote_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_quote_char.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/quote_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:quoteChar "2"^^xsd:integer;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_skip_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_skip_columns.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_columns.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipColumns "apple";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{name}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:age ; 
+        rr:objectMap [ 
+            rml:reference "age" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_skip_initial_space.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_skip_initial_space.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_initial_space.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipInitialSpace "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_skip_rows.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_skip_rows.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_rows.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipRows "1"^^xsd:boolean;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_invalid_value_trim_mode.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_invalid_value_trim_mode.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_start.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "apple";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_line_terminators_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_line_terminators_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/line_terminators.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:lineTerminators "\r\n";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_multiple_char_comment_prefix.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_multiple_char_comment_prefix.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/comment_prefix.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:commentPrefix "$$$";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_multiple_char_delimiter.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_multiple_char_delimiter.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "\t,";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_multiple_char_escape_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_multiple_char_escape_char.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/escape_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:escapeChar "%%%";  # CSVW doesn't provide this in the ontology!
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_multiple_char_quote_char.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_multiple_char_quote_char.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/quote_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:quoteChar "^^";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_negative_int_skip_columns.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_negative_int_skip_columns.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_columns.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipColumns "-1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{name}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:age ; 
+        rr:objectMap [ 
+            rml:reference "age" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_negative_int_skip_rows.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_negative_int_skip_rows.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_rows.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipRows "-1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_quote_char_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_quote_char_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/quote_char.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:quoteChar "^";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_skip_columns_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_skip_columns_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_columns.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipColumns "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{name}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:age ; 
+        rr:objectMap [ 
+            rml:reference "age" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_skip_initial_space_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_skip_initial_space_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_initial_space.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipInitialSpace "true"^^xsd:boolean;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_skip_rows_success.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_skip_rows_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/skip_rows.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:skipRows "1"^^xsd:integer;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_trim_mode_success1.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_trim_mode_success1.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_start.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "start"
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_trim_mode_success2.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_trim_mode_success2.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_end.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "end";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_trim_mode_success3.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_trim_mode_success3.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_start_and_end.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "true"^^xsd:boolean;
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_trim_mode_success4.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_trim_mode_success4.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_start_and_end.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "true";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_trim_mode_success5.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_trim_mode_success5.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_none.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "false"^^xsd:boolean;
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_trim_mode_success6.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_trim_mode_success6.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/trim_mode_none.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:trim "false";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/csvw/validation_unsupported_encoding.ttl
+++ b/Shapes/tests/assets/validation/csvw/validation_unsupported_encoding.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/encoding.csv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:encoding "unsupported";
+    ].
+
+<TriplesMapCSVW>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_jdbc_driver_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_jdbc_driver_database.ttl
@@ -1,0 +1,69 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver2";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_jdbc_dsn_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_jdbc_dsn_database.ttl
@@ -1,0 +1,69 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student2.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_password_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_password_database.ttl
@@ -1,0 +1,71 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "user" ;
+    d2rq:password "pass1" ;
+    d2rq:password "pass2" ;
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_username_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_duplicate_username_database.ttl
@@ -1,0 +1,70 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "user1";
+    d2rq:username "user2";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_invalid_jdbc_dsn_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_invalid_jdbc_dsn_database.ttl
@@ -1,0 +1,68 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN <http://example.com>;
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_login_database_success.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_login_database_success.ttl
@@ -1,0 +1,45 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_missing_properties_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_missing_properties_database.ttl
@@ -1,0 +1,33 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_no_login_database_success.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_no_login_database_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_only_password_database.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_only_password_database.ttl
@@ -1,0 +1,69 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:password "pass";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/d2rq/validation_d2rq_only_username_database_success.ttl
+++ b/Shapes/tests/assets/validation/d2rq/validation_d2rq_only_username_database_success.ttl
@@ -1,0 +1,68 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_NO_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/dcat/validation_dcat_duplicate_distribution.ttl
+++ b/Shapes/tests/assets/validation/dcat/validation_dcat_duplicate_distribution.ttl
@@ -1,0 +1,40 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_JSON_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/json/student2.json" ;
+    ] ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/json/student.json" ;
+    ] .
+
+<TriplesMapDCAT_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/json/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/dcat/validation_dcat_invalid_distribution.ttl
+++ b/Shapes/tests/assets/validation/dcat/validation_dcat_invalid_distribution.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_JSON_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        ex:invalidProperty "This is an invalid property" ;
+    ] .
+
+<TriplesMapDCAT_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/json/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/dcat/validation_dcat_missing_properties_distribution.ttl
+++ b/Shapes/tests/assets/validation/dcat/validation_dcat_missing_properties_distribution.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_JSON_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+    ] .
+
+<TriplesMapDCAT_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/json/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/dcat/validation_dcat_success.ttl
+++ b/Shapes/tests/assets/validation/dcat/validation_dcat_success.ttl
@@ -1,0 +1,117 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_XML_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/xml/student.xml" ;
+        dcat:mediaType "text/xml"
+    ] .
+
+<TriplesMapDCAT_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_XML_source> ;
+        rml:referenceFormulation ql:XPath ;
+        rml:iterator "/students/student" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/xml/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .
+
+<#DCAT_JSON_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/json/student.json" ;
+        dcat:mediaType "application/json"
+    ] .
+
+<TriplesMapDCAT_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/json/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .
+
+<#DCAT_CSV_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/csv/student.csv" ;
+        dcat:mediaType "text/csv"
+    ] .
+
+<TriplesMapDCAT_CSV>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_CSV_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/csv/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .
+
+<#DCAT_RDFXML_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/rdf/student.rdf" ;
+        dcat:mediaType "application/rdf+xml"
+    ] .
+
+<TriplesMapDCAT_RDFXML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_RDFXML_source> ;
+        rml:query """PREFIX foaf: <http://xmlns.com/foaf/0.1/>                  
+                     PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+                     SELECT ?person ?name ?age                                  
+                     WHERE {                                                    
+                         ?person foaf:name ?name .                              
+                         ?person foaf:age ?age .                                
+                     }                                                          
+                     ORDER BY DESC(?age)""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/rdfxml/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/dcat/validation_dcat_unknown_properties_distribution.ttl
+++ b/Shapes/tests/assets/validation/dcat/validation_dcat_unknown_properties_distribution.ttl
@@ -1,0 +1,38 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_JSON_source>
+    a dcat:Dataset ;
+    ex:unknownProperty "This is an unknown property." ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/json/student.json" ;
+    ] ;
+.
+
+<TriplesMapDCAT_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/json/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_csv_file_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_csv_file_success.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_dcat_csv_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_dcat_csv_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_CSV_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/csv/student.csv" ;
+    ] .
+
+<TriplesMapDCAT_CSV>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_CSV_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/csv/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_dcat_json_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_dcat_json_success.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_JSON_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/json/student.json" ;
+    ] .
+
+<TriplesMapDCAT_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/json/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_dcat_rdf_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_dcat_rdf_success.ttl
@@ -1,0 +1,42 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_RDFXML_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/rdf/student.rdf" ;
+    ] .
+
+<TriplesMapDCAT_RDFXML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_RDFXML_source> ;
+        rml:query """PREFIX foaf: <http://xmlns.com/foaf/0.1/>                  
+                     PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+                     SELECT ?person ?name ?age                                  
+                     WHERE {                                                    
+                         ?person foaf:name ?name .                              
+                         ?person foaf:age ?age .                                
+                     }                                                          
+                     ORDER BY DESC(?age)""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/rdfxml/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_dcat_xml_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_dcat_xml_success.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_XML_source>
+    a dcat:Dataset ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/xml/student.xml" ;
+    ] .
+
+<TriplesMapDCAT_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_XML_source> ;
+        rml:referenceFormulation ql:XPath ;
+        rml:iterator "/students/student" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/xml/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_duplicate_iterator.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_duplicate_iterator.ttl
@@ -1,0 +1,30 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapJSON>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/json/student.json" ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+        rml:iterator "$.students[*]" ;
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_duplicate_query.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_duplicate_query.ttl
@@ -1,0 +1,51 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_JSON_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_JSON_source> ;
+        rml:query "duplicate" ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:JSONPath;
+        rml:iterator "$.results.bindings[*]";
+    ] ;
+
+    rr:subjectMap [ rr:template "{actor.value}_JSON" ];
+
+    rr:predicateObjectMap [
+        rr:predicateMap [ rr:constant foaf:name ];
+        rr:objectMap [
+            rml:reference "name.value";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/rml/validation_duplicate_reference_formulation.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_duplicate_reference_formulation.ttl
@@ -1,0 +1,30 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapJSON>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/json/student.json" ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:referenceFormulation ql:XPath ;
+        rml:iterator "$.students.[*]" ;
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_duplicate_source.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_duplicate_source.ttl
@@ -1,0 +1,30 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapJSON>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/json/student.json" ;
+        rml:source "tests/assets/json/student2.json" ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_duplicate_sql_version.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_duplicate_sql_version.ttl
@@ -1,0 +1,46 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rr:sqlVersion rr:SQL2016;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_invalid_reference_formulation.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_invalid_reference_formulation.ttl
@@ -1,0 +1,50 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_JSON_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_JSON_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:InvalidFormulation;
+        rml:iterator "$.results.bindings[*]";
+    ] ;
+
+    rr:subjectMap [ rr:template "{actor.value}_JSON" ];
+
+    rr:predicateObjectMap [
+        rr:predicateMap [ rr:constant foaf:name ];
+        rr:objectMap [
+            rml:reference "name.value";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/rml/validation_invalid_source.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_invalid_source.ttl
@@ -1,0 +1,36 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#DCAT_CSV_source>
+    a dcat:InvalidClass ;
+    dcat:distribution [
+        a dcat:Distribution;
+        dcat:downloadURL "http://127.0.0.1:8000/tests/assets/csv/student.csv" ;
+        dcat:mediaType "text/csv"
+    ] .
+
+<TriplesMapDCAT_CSV>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#DCAT_CSV_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/csv/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_invalid_sql_version.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_invalid_sql_version.ttl
@@ -1,0 +1,45 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL1234;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_json_file_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_json_file_success.ttl
@@ -1,0 +1,29 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapJSON>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/json/student.json" ;
+        rml:referenceFormulation ql:JSONPath ;
+        rml:iterator "$.students.[*]" ;
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_missing_iterator.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_missing_iterator.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapJSON>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/json/student.json" ;
+        rml:referenceFormulation ql:JSONPath ;
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_missing_query.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_missing_query.ttl
@@ -1,0 +1,37 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_JSON_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_JSON_source> ;
+        rml:referenceFormulation ql:JSONPath;
+        rml:iterator "$.results.bindings[*]";
+    ] ;
+
+    rr:subjectMap [ rr:template "{actor.value}_JSON" ];
+
+    rr:predicateObjectMap [
+        rr:predicateMap [ rr:constant foaf:name ];
+        rr:objectMap [
+            rml:reference "name.value";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/rml/validation_missing_reference_formulation.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_missing_reference_formulation.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapJSON>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/json/student.json" ;
+        rml:iterator "$.students[*]"
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_missing_source.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_missing_source.ttl
@@ -1,0 +1,27 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_rdf_file_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_rdf_file_success.ttl
@@ -1,0 +1,32 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<TriplesMapDCAT_RDFXML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source "tests/assets/rdf/student.rdf" ;
+        rml:query """PREFIX foaf: <http://xmlns.com/foaf/0.1/>                  
+                     PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+                     SELECT ?person ?name ?age                                  
+                     WHERE {                                                    
+                         ?person foaf:name ?name .                              
+                         ?person foaf:age ?age .                                
+                     }                                                          
+                     ORDER BY DESC(?age)""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/rdfxml/{name}" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "age"
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/rml/validation_sparql_json_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_sparql_json_success.ttl
@@ -1,0 +1,50 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_JSON_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_JSON_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:JSONPath;
+        rml:iterator "$.results.bindings[*]";
+    ] ;
+
+    rr:subjectMap [ rr:template "{actor.value}_JSON" ];
+
+    rr:predicateObjectMap [
+        rr:predicateMap [ rr:constant foaf:name ];
+        rr:objectMap [
+            rml:reference "name.value";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/rml/validation_sparql_xml_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_sparql_xml_success.ttl
@@ -1,0 +1,50 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/rml/validation_sql_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_sql_success.ttl
@@ -1,0 +1,45 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    d2rq:username "username";
+    d2rq:password "password";
+    .
+
+<TriplesMapSQL_SQLITE_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ rr:template "http://example.com/{NAME}_LOGIN" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "TEST_{AGE}_{ID}" ;
+            rr:termType rr:Literal ;
+        ]
+    ] ;
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rr:template "http://example.com/{ID}" ;
+            rr:termType rr:IRI
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rml/validation_tsv_file_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_tsv_file_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<#CSVW_source> a csvw:Table;
+    csvw:url "tests/assets/csv/student.tsv" ;
+    csvw:dialect [
+        a csvw:Dialect;
+        csvw:delimiter "\t";
+    ].
+
+<TriplesMapTSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source <#CSVW_source> ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rml/validation_xml_file_success.ttl
+++ b/Shapes/tests/assets/validation/rml/validation_xml_file_success.ttl
@@ -1,0 +1,29 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapXML>
+    a rr:TriplesMap;
+
+    rml:logicalSource [ 
+        rml:source "tests/assets/xml/student.xml" ;
+        rml:referenceFormulation ql:XPath ;
+        rml:iterator "/students/student" ;
+    ];
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{./id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "./name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_condition_refobjectmap_success.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_condition_refobjectmap_success.ttl
@@ -1,0 +1,64 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:joinCondition [
+        rr:child "Sport" ;
+        rr:parent "ID" ;
+      ];
+  rr:parentTriplesMap <TriplesMap2> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_duplicate_child_refobjectmap.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_duplicate_child_refobjectmap.ttl
@@ -1,0 +1,65 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:joinCondition [
+        rr:child "Sport" ;
+        rr:child "Name" ;
+        rr:parent "ID" ;
+      ];
+  rr:parentTriplesMap <TriplesMap2> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_duplicate_parent_refobjectmap.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_duplicate_parent_refobjectmap.ttl
@@ -1,0 +1,65 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:joinCondition [
+        rr:child "Sport" ;
+        rr:parent "Name" ;
+        rr:parent "ID" ;
+      ];
+  rr:parentTriplesMap <TriplesMap2> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_duplicate_reference.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_duplicate_reference.ttl
@@ -1,0 +1,29 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+            rml:reference "name2" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_duplicate_refobjectmap.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_duplicate_refobjectmap.ttl
@@ -1,0 +1,61 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:parentTriplesMap <TriplesMap2> ;
+  rr:parentTriplesMap <TriplesMap1> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_edge_cases_success.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_edge_cases_success.ttl
@@ -1,0 +1,77 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rr:template "http://example.com/{id}" ;
+            rr:termType rr:IRI ;
+        ]
+    ];
+
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:id1 ; 
+        rr:objectMap [ 
+            rml:reference "iri" ;
+            rr:termType rr:IRI ;
+        ]
+    ];
+
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:id2 ; 
+        rr:objectMap [ 
+            rml:reference "id" ;
+            rr:termType rr:Literal ;
+        ]
+    ];
+
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:age ; 
+        rr:objectMap [ 
+            rr:template "{age}" ;
+            rr:termType rr:Literal ;
+        ]
+    ].
+
+<TriplesMapCSV2>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rml:reference "iri" ;
+        rr:termType rr:IRI ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicateMap [
+            rml:reference "iri" ;
+            rr:termType rr:IRI ;
+        ];
+        rr:objectMap [ 
+            rr:template "{id}" ;
+            rr:termType rr:Literal ;
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_invalid_condition_refobjectmap.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_condition_refobjectmap.ttl
@@ -1,0 +1,65 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:joinCondition [
+        rr:child "Sport" ;
+        rr:parent "ID" ;
+        rr:invalid "oooops" ;
+      ];
+  rr:parentTriplesMap <TriplesMap2> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_invalid_object_map.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_object_map.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rr:example "INVALID" ;
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_invalid_predicate_map.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_predicate_map.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate [ rr:example "INVALID" ] ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_invalid_predicate_object_map.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_predicate_object_map.ttl
@@ -1,0 +1,27 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_invalid_refobjectmap.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_refobjectmap.ttl
@@ -1,0 +1,60 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:invalid <TriplesMap2> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_invalid_subject_map.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_subject_map.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:example "INVALID" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_invalid_term_type.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_term_type.ttl
@@ -1,0 +1,29 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+        rr:termType rr:Literal ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_invalid_triples_map.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_invalid_triples_map.ttl
@@ -1,0 +1,32 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+
+    rr:example [
+        rr:invalid "Invalid!" ;
+    ] ;
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_maps_success.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_maps_success.ttl
@@ -1,0 +1,28 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+            rml:reference "name" ; 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_missing_reference.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_missing_reference.ttl
@@ -1,0 +1,27 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+@base <http://example.com/base/> .
+
+<TriplesMapCSV>
+    a rr:TriplesMap ;
+        
+    rml:logicalSource [ 
+        rml:source "tests/assets/csv/student.csv" ;
+        rml:referenceFormulation ql:CSV ;
+    ];
+	
+    rr:subjectMap [ 
+        rr:template "http://example.com/{id}" ;
+    ]; 
+	
+    rr:predicateObjectMap [ 
+        rr:predicate foaf:name ; 
+        rr:objectMap [ 
+        ]
+    ].

--- a/Shapes/tests/assets/validation/rr/validation_refobjectmap_success.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_refobjectmap_success.ttl
@@ -1,0 +1,60 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@prefix activity: <http://example.com/activity/> .
+@base <http://example.com/base/> .
+
+<TriplesMap2>
+  a rr:TriplesMap;
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/{Sport}" ];
+
+  rr:predicateObjectMap [
+    rr:predicate rdf:type ;
+    rr:object activity:Sport ;
+  ] .
+
+<TriplesMap1>
+  a rr:TriplesMap;
+
+  rml:logicalSource [ 
+    rml:source "student.csv";
+    rml:referenceFormulation ql:CSV
+  ];
+
+  rr:subjectMap [ rr:template "http://example.com/Student/{ID}/{Name}" ];
+	
+  rr:predicateObjectMap [ 
+    rr:predicate rdf:type ;
+    rr:object foaf:Person ;
+  ];
+		
+  rr:predicateObjectMap [ 
+    rr:predicate ex:id ;
+    rr:objectMap [ rml:reference "ID"; ]
+  ];
+
+  rr:predicateObjectMap [ 
+    rr:predicate foaf:name ;
+    rr:objectMap [ rml:reference "Name" ]
+  ];
+ 
+  rr:predicateObjectMap [ 
+    rr:predicate ex:Sport ;
+    rr:objectMap <RefObjectMap1>
+  ] .
+
+ 
+<RefObjectMap1>
+  a rr:RefObjectMap;
+  rr:parentTriplesMap <TriplesMap2> .
+
+

--- a/Shapes/tests/assets/validation/rr/validation_rr_class_success.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_rr_class_success.ttl
@@ -1,0 +1,38 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rml:query """SELECT id, name, age FROM students;""" ;
+    ] ;
+
+    rr:subjectMap [ 
+        rr:template "http://example.com/{NAME}_NO_LOGIN" ;
+        rr:class foaf:Person ;
+    ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/rr/validation_rr_table_name_success.ttl
+++ b/Shapes/tests/assets/validation/rr/validation_rr_table_name_success.ttl
@@ -1,0 +1,35 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SQL_SQLITE_NO_LOGIN_source>
+    a d2rq:Database ;
+    d2rq:jdbcDSN "jdbc:sqlite:///tests/assets/sql/student.db";
+    d2rq:jdbcDriver "com.sqlite.jdbc.Driver";
+    .
+
+<TriplesMapSQL_SQLITE_NO_LOGIN>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SQL_SQLITE_NO_LOGIN_source> ;
+        rr:sqlVersion rr:SQL2008;
+        rr:tableName "students";
+    ] ;
+
+    rr:subjectMap [ rml:reference "NAME" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:age;
+        rr:objectMap [
+            rml:reference "AGE"
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_duplicate_endpoint.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_duplicate_endpoint.ttl
@@ -1,0 +1,50 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:endpoint <http://dbpedia.org/sparql2/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_duplicate_result_format.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_duplicate_result_format.ttl
@@ -1,0 +1,50 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_duplicate_supported_language.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_duplicate_supported_language.ttl
@@ -1,0 +1,51 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_JSON_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:supportedLanguage sd:SPARQL10Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_JSON_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:JSONPath;
+        rml:iterator "$.results.bindings[*]";
+    ] ;
+
+    rr:subjectMap [ rr:template "{actor.value}_JSON" ];
+
+    rr:predicateObjectMap [
+        rr:predicateMap [ rr:constant foaf:name ];
+        rr:objectMap [
+            rml:reference "name.value";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_endpoint.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_endpoint.ttl
@@ -1,0 +1,49 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint "http://dbpedia.org/sparql/";
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_result_format.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_result_format.ttl
@@ -1,0 +1,49 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_INVALID> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_result_format2.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_result_format2.ttl
@@ -1,0 +1,49 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat "http://www.w3.org/ns/formats/SPARQL_Results_XML" ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_supported_language.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_invalid_supported_language.ttl
@@ -1,0 +1,49 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:INVALID ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_missing_properties.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_missing_properties.ttl
@@ -1,0 +1,46 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_success.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_success.ttl
@@ -1,0 +1,87 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .
+
+<#SPARQL_JSON_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_JSON> ;
+    .
+
+<TriplesMapSPARQL_JSON>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_JSON_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:JSONPath;
+        rml:iterator "$.results.bindings[*]";
+    ] ;
+
+    rr:subjectMap [ rr:template "{actor.value}_JSON" ];
+
+    rr:predicateObjectMap [
+        rr:predicateMap [ rr:constant foaf:name ];
+        rr:objectMap [
+            rml:reference "name.value";
+        ]
+    ] .
+

--- a/Shapes/tests/assets/validation/sparql/validation_sparql_unknown_property.ttl
+++ b/Shapes/tests/assets/validation/sparql/validation_sparql_unknown_property.ttl
@@ -1,0 +1,50 @@
+@prefix rr: <http://www.w3.org/ns/r2rml#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.com/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rml: <http://semweb.mmlab.be/ns/rml#> .
+@prefix ql: <http://semweb.mmlab.be/ns/ql#> .
+@base <http://example.com/base/> .
+@prefix sd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+
+<#SPARQL_XML_source>
+    a sd:Service ;
+    sd:endpoint <http://dbpedia.org/sparql/> ;
+    sd:supportedLanguage sd:SPARQL11Query ;
+    sd:resultFormat <http://www.w3.org/ns/formats/SPARQL_Results_XML> ;
+    ex:unknownProperty "This is an unknown property";
+    .
+
+<TriplesMapSPARQL_XML>
+    a rr:TriplesMap;
+    rml:logicalSource [
+        rml:source <#SPARQL_XML_source> ;
+        rml:query """
+            PREFIX dbo: <http://dbpedia.org/ontology/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT DISTINCT ?actor ?name ?birthDate WHERE {
+                ?tvshow rdf:type dbo:TelevisionShow .
+                ?tvshow rdfs:label "Friends"@en .
+                ?tvshow dbo:starring ?actor .
+                ?actor foaf:name ?name .
+                ?actor dbo:birthDate ?birthDate .
+            }
+        """;
+        rml:referenceFormulation ql:XPath;
+        rml:iterator "//sr:result";
+    ] ;
+
+    rr:subjectMap [ rr:template "{./sr:binding[@name=\"actor\"]/sr:uri}_XML" ];
+
+    rr:predicateObjectMap [
+        rr:predicate foaf:name;
+        rr:objectMap [
+            rml:reference "./sr:binding[@name=\"name\"]/sr:literal";
+        ]
+    ] .


### PR DESCRIPTION
Initial SHACL shapes for R2RML and RML mapping rules.
These shapes were created manually, based upon the R2RML, RML, CSVW, SD,
D2RQ, and DCAT specifications.

These SHACL shapes validate:
- R2RML Graph Map
- R2RML Logical Table
- R2RML Object Map
- R2RML Predicate Map
- R2RML Predicate Object Map
- R2RML Subject Map
- R2RML Triples Map
- R2RML Reference Object Map
- RML Logical Source
- RML reference
- CSVW for rml:source (CSV files)
- SD for rml:source (SPARQL endpoints)
- D2RQ for rml:source (RDBs)
- DCAT Dataset & Distribution for rml:source (W3C DCAT)

All these shapes can be combined into one giant shape (included as well)
with ./generate_shape.py to make it easier for for validating mapping
rules with existing SHACL tools.

These shapes are tested with a set of test cases and are executed by
Github Actions. These test cases verify if required properties are
present and verifies the cardinalities of required and optional
properties. Unknown properties are currently marked as a violation by
following a Closed World Assumption using `sh:closed "true"^^xsd:boolean`.
This part can be refactored later to allow extensions, but currently a
strict validation is enforced which does not allow deviations from the
mentioned specifications.

Fixes #35 
CC: @pmaria 